### PR TITLE
Extract KNative and Kubernetes clients

### DIFF
--- a/knative.go
+++ b/knative.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	servingv1alpha1 "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
+	"time"
+)
+
+type KNativeClient struct {
+	client *servingv1alpha1.ServingV1alpha1Client
+}
+
+func NewKnativeClient(config *rest.Config) KNativeClient {
+	servingClient, err := servingv1alpha1.NewForConfig(config)
+	if err != nil {
+		panic(err)
+	}
+
+	return KNativeClient{client: servingClient}
+}
+
+func (kNativeClient *KNativeClient) Services(namespace string) (*v1alpha1.ServiceList, error) {
+	return kNativeClient.client.Services(namespace).List(v1.ListOptions{})
+}
+
+// Pushes an event to the "events" channel received when an serving is added/deleted/updated.
+func (kNativeClient *KNativeClient) WatchChangesInServices(namespace string, events chan<- string, stopChan <-chan struct{}) {
+	restClient := kNativeClient.client.RESTClient()
+
+	watchlist := cache.NewListWatchFromClient(restClient, "services", namespace,
+		fields.Everything())
+
+	_, controller := cache.NewInformer(
+		watchlist,
+		&v1alpha1.Service{},
+		time.Second*1,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				events <- "change"
+			},
+
+			DeleteFunc: func(obj interface{}) {
+				events <- "change"
+			},
+
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				if oldObj != newObj {
+					events <- "change"
+				}
+			},
+		},
+	)
+
+	controller.Run(stopChan)
+}

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	"path/filepath"
+	"time"
+)
+
+const labelPrefix = "serving.knative.dev/revision="
+
+type KubernetesClient struct {
+	client *kubernetes.Clientset
+}
+
+func NewKubernetesClient(config *rest.Config) KubernetesClient {
+	k8sClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err)
+	}
+
+	return KubernetesClient{client: k8sClient}
+}
+
+func Config() *rest.Config {
+	// Get the config, $HOME/.kube/config
+	// TODO: Read from env var
+	var kubeconfig *string
+	if home := homeDir(); home != "" {
+		kubeconfig = flag.String(
+			"kubeconfig",
+			filepath.Join(home, ".kube", "config"),
+			"(optional) absolute path to the kubeconfig file",
+		)
+	} else {
+		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	}
+	flag.Parse()
+
+	var config *rest.Config
+	// use the current context in kubeconfig
+	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	if err != nil {
+		config, _ = rest.InClusterConfig()
+	}
+
+	return config
+}
+
+func (kubernetesClient *KubernetesClient) EndpointsForRevision(namespace string, revisionName string) (*v1.EndpointsList, error) {
+	listOptions := meta_v1.ListOptions{LabelSelector: labelPrefix + revisionName}
+	return kubernetesClient.client.CoreV1().Endpoints(namespace).List(listOptions)
+}
+
+func HTTPPortForEndpointSubset(subset v1.EndpointSubset) (uint32, error) {
+	for _, port := range subset.Ports {
+		if port.Name == "http" {
+			return uint32(port.Port), nil
+		}
+	}
+
+	return 0, fmt.Errorf("http port not found")
+}
+
+// Pushes an event to the "events" channel received when an endpoint is added/deleted/updated.
+func (kubernetesClient *KubernetesClient) WatchChangesInEndpoints(namespace string, events chan<- string, stopChan <-chan struct{}) {
+	restClient := kubernetesClient.client.CoreV1().RESTClient()
+
+	watchlist := cache.NewListWatchFromClient(restClient, "endpoints", namespace,
+		fields.Everything())
+
+	_, controller := cache.NewInformer(
+		watchlist,
+		&v1.Endpoints{},
+		time.Second*1,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				events <- "change"
+			},
+
+			DeleteFunc: func(obj interface{}) {
+				events <- "change"
+			},
+
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				if oldObj != newObj {
+					events <- "change"
+				}
+			},
+		},
+	)
+
+	controller.Run(stopChan)
+}


### PR DESCRIPTION
Just a first step towards making the code more modular.
The PR extract the clients for KNative and Kubernetes. It does not change the behaviour.
In the future we can think about creating specific packages for them.