### PR TITLE
Basic deployment yaml for kourier with knative

### DIFF
--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -1,0 +1,139 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: 3scale-kourier
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: 3scale-kourier
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: 3scale-kourier
+    spec:
+      containers:
+        - args:
+            - -c
+            - /tmp/config/envoy-bootstrap.yaml
+          image: envoyproxy/envoy-alpine:latest
+          imagePullPolicy: Always
+          name: envoy
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - name: config-volume
+              mountPath: /tmp/config
+        - image: quay.io/3scale/kourier:v0.0.1
+          imagePullPolicy: Always
+          name: kourier
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      volumes:
+        - name: config-volume
+          configMap:
+            name: kourier-bootstrap
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccountName: 3scale-kourier
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: 3scale-kourier
+  namespace: knative-serving
+rules:
+  - apiGroups: [""]
+    resources: [ "endpoints", "namespaces", "services" ]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [ "serving.knative.dev" ]
+    resources: [ "*" ]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [ "apiextensions.k8s.io" ]
+    resources: [ "customresourcedefinitions" ]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: 3scale-kourier
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: 3scale-kourier
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 3scale-kourier
+subjects:
+  - kind: ServiceAccount
+    name: 3scale-kourier
+    namespace: knative-serving
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: 3scale-kourier
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kourier-bootstrap
+data:
+  envoy-bootstrap.yaml: |
+    admin:
+      access_log_path: /tmp/test
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 19000
+    dynamic_resources:
+      ads_config:
+        api_type: GRPC
+        grpc_services:
+          - envoy_grpc:
+              cluster_name: xds_cluster
+      cds_config:
+        ads: {}
+      lds_config:
+        ads: {}
+    node:
+      cluster: test-cluster
+      id: 3scale-courier
+    static_resources:
+      clusters:
+        - connect_timeout: 1s
+          hosts:
+            - socket_address:
+                address: "127.0.0.1"
+                port_value: 18000
+          http2_protocol_options: {}
+          name: xds_cluster
+          type: STRICT_DNS

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -338,7 +338,7 @@ func envoyListener(httpConnectionManager *v2.HttpConnectionManager) envoyv2.List
 					Protocol: core.TCP,
 					Address:  "0.0.0.0",
 					PortSpecifier: &core.SocketAddress_PortValue{
-						PortValue: uint32(80),
+						PortValue: uint32(8080),
 					},
 				},
 			},


### PR DESCRIPTION
* Adds kourier-knative.yaml with all the required to deploy kourier integration with knative
* Changes default listening port of Envoy listener_0 to 8080