### PR TITLE
Use ClusterIngress instead of Service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ run: ## runs kourier locally with "go run"
 	@echo "[i] Remember to have a valid kubeconfig in $(HOME)/.kube/config"
 	@go run ./cmd/kourier/main.go
 
-docker-run-envoy: docker-run ## Runs envoy in a docker
+docker-run-envoy: ## Runs envoy in a docker
 	docker run --rm  -p 19000:19000 -p 10000:10000 --link kourier --name kourier_envoy -v $(PWD)/conf/:/tmp/conf -ti envoyproxy/envoy-alpine:latest -c /tmp/conf/envoy-bootstrap.yaml
 
 docker-run: docker-build ## Runs kourier in a docker

--- a/cmd/kourier/main.go
+++ b/cmd/kourier/main.go
@@ -37,20 +37,20 @@ func main() {
 	stopChanEndpoints := make(chan struct{})
 	go kubernetesClient.WatchChangesInEndpoints(namespace, eventsChan, stopChanEndpoints)
 
-	stopChanServings := make(chan struct{})
-	go knativeClient.WatchChangesInServices(namespace, eventsChan, stopChanServings)
+	stopChanClusterIngress := make(chan struct{})
+	go knativeClient.WatchChangesInClusterIngress(namespace, eventsChan, stopChanClusterIngress)
 
 	envoyXdsServer := envoy.NewEnvoyXdsServer(gatewayPort, managementPort, kubernetesClient)
 	go envoyXdsServer.RunManagementServer()
 	go envoyXdsServer.RunGateway()
 
 	for {
-		serviceList, err := knativeClient.Services(namespace)
+		clusterIngresses, err := knativeClient.ClusterIngresses()
 		if err != nil {
 			panic(err)
 		}
 
-		envoyXdsServer.SetSnapshotForKnativeServices(nodeID, serviceList)
+		envoyXdsServer.SetSnapshotForClusterIngresses(nodeID, clusterIngresses)
 
 		<-eventsChan // Block until there's a change in the endpoints or servings
 	}

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -2,7 +2,6 @@ package envoy
 
 import (
 	"context"
-	"courier/pkg/knative"
 	"courier/pkg/kubernetes"
 	"fmt"
 	envoyv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -20,9 +19,10 @@ import (
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	kubev1 "k8s.io/api/core/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1alpha12 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"net"
 	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -117,100 +117,140 @@ func (envoyXdsServer *EnvoyXdsServer) RunGateway() {
 	}
 }
 
-func (envoyXdsServer *EnvoyXdsServer) SetSnapshotForKnativeServices(nodeId string, services *v1alpha1.ServiceList) {
-	virtualHosts := []*route.VirtualHost{}
+func (envoyXdsServer *EnvoyXdsServer) SetSnapshotForClusterIngresses(nodeId string, clusterIngresses *v1alpha12.ClusterIngressList) {
+	var virtualHosts []*route.VirtualHost
 	var routeCache []cache.Resource
 	var clusterCache []cache.Resource
 
-	for _, service := range services.Items {
+	for i, clusterIngress := range clusterIngresses.Items {
 
-		if service.Status.URL == nil {
-			log.Infof("Empty URL skipping")
-			break
-		}
+		routeName := getRouteName(clusterIngress)
+		routeNamespace := getRouteNamespace(clusterIngress)
+		log.WithFields(log.Fields{"name": routeName, "namespace": routeNamespace}).Info("Knative ClusterIngress found")
 
-		log.WithFields(log.Fields{"name": service.GetName(), "host": service.Status.URL.Host}).Info("Knative serving service found")
+		for _, rule := range clusterIngress.Spec.Rules {
 
-		wrs := []*route.WeightedCluster_ClusterWeight{}
-		for _, traffic := range service.Status.Traffic {
-			endpointList, err := envoyXdsServer.kubeClient.EndpointsForRevision(service.Namespace, traffic.RevisionName)
+			var ruleRoute []*route.Route
+			domains := rule.Hosts
 
-			if err != nil {
-				log.Errorf("%s", err)
-				break
+			for _, httpPath := range rule.HTTP.Paths {
+
+				path := "/"
+				if httpPath.Path != "" {
+					path = httpPath.Path
+				}
+
+				headers := httpPath.AppendHeaders
+
+				var wrs []*route.WeightedCluster_ClusterWeight
+
+				for _, split := range httpPath.Splits {
+
+					endpointList, err := envoyXdsServer.kubeClient.EndpointsForRevision(split.ServiceNamespace, split.ServiceName)
+
+					if err != nil {
+						log.Errorf("%s", err)
+						break
+					}
+
+					service, err := envoyXdsServer.kubeClient.ServiceForRevision(split.ServiceNamespace, split.ServiceName)
+
+					if err != nil {
+						log.Errorf("%s", err)
+						break
+					}
+
+					var targetPort int32
+					http2 := false
+					for _, port := range service.Spec.Ports {
+						if port.Port == split.ServicePort.IntVal || port.Name == split.ServicePort.StrVal {
+							targetPort = port.TargetPort.IntVal
+							http2 = port.Name == "http2" || port.Name == "h2c"
+						}
+					}
+
+					lbEndpoints := lbEndpointsForKubeEndpoints(endpointList, targetPort)
+
+					connectTimeout := 5 * time.Second
+					cluster := clusterForRevision(split.ServiceName, connectTimeout, lbEndpoints, http2, path)
+					clusterCache = append(clusterCache, &cluster)
+
+					weightedCluster := weightedCluster(split.ServiceName, uint32(split.Percent), path, headers)
+
+					wrs = append(wrs, &weightedCluster)
+
+				}
+
+				r := createRouteForRevision(routeName, i, path, wrs)
+
+				ruleRoute = append(ruleRoute, &r)
+				routeCache = append(routeCache, &r)
+
 			}
 
-			lbEndpoints := lbEndpointsForKubeEndpoints(service, endpointList)
-
-			connectTimeout := 5 * time.Second
-			cluster := clusterForRevision(traffic.RevisionName, connectTimeout, lbEndpoints)
-
-			if knative.ServiceHTTP2Enabled(service) {
-				cluster.Http2ProtocolOptions = &core.Http2ProtocolOptions{}
+			virtualHost := route.VirtualHost{
+				Name:    routeName,
+				Domains: domains,
+				Routes:  ruleRoute,
 			}
-			clusterCache = append(clusterCache, &cluster)
 
-			weightedCluster := weightedCluster(
-				traffic.RevisionName, service.Namespace, uint32(traffic.Percent),
-			)
-			wrs = append(wrs, &weightedCluster)
-
+			virtualHosts = append(virtualHosts, &virtualHost)
 		}
-
-		r := routeWithWeightedClusters(service.Name, wrs)
-		routeCache = append(routeCache, &r)
-
-		domains, err := knative.DomainsFromService(&service)
-
-		if err != nil {
-			log.Errorf("cannot get domains for service %s : %s", service.Name, err)
-		}
-
-		virtualHost := route.VirtualHost{
-			Name:    service.GetName(),
-			Domains: domains,
-			Routes:  []*route.Route{&r},
-		}
-
-		virtualHosts = append(virtualHosts, &virtualHost)
 
 	}
 
 	manager := httpConnectionManager(virtualHosts)
-
 	l := envoyListener(&manager)
-
 	listenerCache := []cache.Resource{&l}
 
 	snapshotVersion, errUUID := uuid.NewUUID()
-
 	if errUUID != nil {
 		log.Error(errUUID)
 		return
 	}
 
-	snapshot := cache.NewSnapshot(
-		snapshotVersion.String(), nil, clusterCache, routeCache, listenerCache,
-	)
+	snapshot := cache.NewSnapshot(snapshotVersion.String(), nil, clusterCache, routeCache, listenerCache)
 
 	err := envoyXdsServer.snapshotCache.SetSnapshot(nodeId, snapshot)
-
 	if err != nil {
 		log.Error(err)
 	}
 }
 
-func lbEndpointsForKubeEndpoints(service v1alpha1.Service, kubeEndpoints *kubev1.EndpointsList) []*endpoint.LbEndpoint {
-	result := []*endpoint.LbEndpoint{}
+func createRouteForRevision(routeName string, i int, path string, wrs []*route.WeightedCluster_ClusterWeight) route.Route {
+	r := route.Route{
+		Name: routeName + "_" + strconv.Itoa(i),
+		Match: &route.RouteMatch{
+			PathSpecifier: &route.RouteMatch_Prefix{
+				Prefix: path,
+			},
+		},
+		Action: &route.Route_Route{Route: &route.RouteAction{
+			ClusterSpecifier: &route.RouteAction_WeightedClusters{
+				WeightedClusters: &route.WeightedCluster{
+					Clusters: wrs,
+				},
+			},
+		}},
+	}
+	return r
+}
+
+func getRouteNamespace(ingress v1alpha12.ClusterIngress) string {
+
+	return ingress.Labels["serving.knative.dev/routeNamespace"]
+}
+
+func getRouteName(ingress v1alpha12.ClusterIngress) string {
+
+	return ingress.Labels["serving.knative.dev/route"]
+}
+
+func lbEndpointsForKubeEndpoints(kubeEndpoints *kubev1.EndpointsList, targetPort int32) []*endpoint.LbEndpoint {
+	var result []*endpoint.LbEndpoint
 
 	for _, kubeEndpoint := range kubeEndpoints.Items {
 		for _, subset := range kubeEndpoint.Subsets {
-
-			port, err := knative.HTTPPortForEndpointSubset(service, subset)
-
-			if err != nil {
-				break
-			}
 
 			for _, address := range subset.Addresses {
 
@@ -220,7 +260,7 @@ func lbEndpointsForKubeEndpoints(service v1alpha1.Service, kubeEndpoints *kubev1
 							Protocol: core.TCP,
 							Address:  address.IP,
 							PortSpecifier: &core.SocketAddress_PortValue{
-								PortValue: port,
+								PortValue: uint32(targetPort),
 							},
 							Ipv4Compat: true,
 						},
@@ -242,15 +282,16 @@ func lbEndpointsForKubeEndpoints(service v1alpha1.Service, kubeEndpoints *kubev1
 	return result
 }
 
-func clusterForRevision(revisionName string, connectTimeout time.Duration, lbEndpoints []*endpoint.LbEndpoint) envoyv2.Cluster {
-	return envoyv2.Cluster{
-		Name: "knative_" + revisionName,
+func clusterForRevision(revisionName string, connectTimeout time.Duration, lbEndpoints []*endpoint.LbEndpoint, http2 bool, path string) envoyv2.Cluster {
+
+	cluster := envoyv2.Cluster{
+		Name: revisionName + path,
 		ClusterDiscoveryType: &envoyv2.Cluster_Type{
 			Type: envoyv2.Cluster_STRICT_DNS,
 		},
 		ConnectTimeout: &connectTimeout,
 		LoadAssignment: &envoyv2.ClusterLoadAssignment{
-			ClusterName: "knative_" + revisionName,
+			ClusterName: revisionName + path,
 			Endpoints: []*endpoint.LocalityLbEndpoints{
 				{
 					LbEndpoints: lbEndpoints,
@@ -258,51 +299,40 @@ func clusterForRevision(revisionName string, connectTimeout time.Duration, lbEnd
 			},
 		},
 	}
+
+	if http2 {
+		cluster.Http2ProtocolOptions = &core.Http2ProtocolOptions{}
+	}
+
+	return cluster
 }
 
-func weightedCluster(revisionName string, namespace string, trafficPerc uint32) route.WeightedCluster_ClusterWeight {
-	return route.WeightedCluster_ClusterWeight{
-		Name: "knative_" + revisionName,
-		Weight: &types.UInt32Value{
-			Value: trafficPerc,
-		},
-		RequestHeadersToAdd: []*core.HeaderValueOption{{
+func weightedCluster(revisionName string, trafficPerc uint32, path string, headersToAdd map[string]string) route.WeightedCluster_ClusterWeight {
+
+	var headers []*core.HeaderValueOption
+
+	for k, v := range headersToAdd {
+
+		header := core.HeaderValueOption{
 			Header: &core.HeaderValue{
-				Key:   namespaceHeader,
-				Value: namespace,
+				Key:   k,
+				Value: v,
 			},
 			Append: &types.BoolValue{
 				Value: true,
 			},
-		},
-			{
-				Header: &core.HeaderValue{
-					Key:   revisionHeader,
-					Value: revisionName,
-				},
-				Append: &types.BoolValue{
-					Value: true,
-				},
-			},
-		},
-	}
-}
+		}
 
-func routeWithWeightedClusters(serviceName string, weightedClusters []*route.WeightedCluster_ClusterWeight) route.Route {
-	return route.Route{
-		Name: "knative_" + serviceName,
-		Match: &route.RouteMatch{
-			PathSpecifier: &route.RouteMatch_Prefix{
-				Prefix: "/",
-			},
+		headers = append(headers, &header)
+
+	}
+
+	return route.WeightedCluster_ClusterWeight{
+		Name: revisionName + path,
+		Weight: &types.UInt32Value{
+			Value: trafficPerc,
 		},
-		Action: &route.Route_Route{Route: &route.RouteAction{
-			ClusterSpecifier: &route.RouteAction_WeightedClusters{
-				WeightedClusters: &route.WeightedCluster{
-					Clusters: weightedClusters,
-				},
-			},
-		}},
+		RequestHeadersToAdd: headers,
 	}
 }
 
@@ -338,7 +368,7 @@ func envoyListener(httpConnectionManager *v2.HttpConnectionManager) envoyv2.List
 					Protocol: core.TCP,
 					Address:  "0.0.0.0",
 					PortSpecifier: &core.SocketAddress_PortValue{
-						PortValue: uint32(80),
+						PortValue: uint32(8080),
 					},
 				},
 			},

--- a/pkg/knative/knative.go
+++ b/pkg/knative/knative.go
@@ -1,102 +1,56 @@
 package knative
 
 import (
-	"fmt"
-	log "github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
-	servingv1alpha1 "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
+
+	networkingClientSet "knative.dev/serving/pkg/client/clientset/versioned/typed/networking/v1alpha1"
+	servingClientSet "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
+
 	"time"
 )
 
 type KNativeClient struct {
-	client *servingv1alpha1.ServingV1alpha1Client
+	servingClient    *servingClientSet.ServingV1alpha1Client
+	networkingClient *networkingClientSet.NetworkingV1alpha1Client
 }
 
 func NewKnativeClient(config *rest.Config) KNativeClient {
-	servingClient, err := servingv1alpha1.NewForConfig(config)
+	servingClient, err := servingClientSet.NewForConfig(config)
 	if err != nil {
 		panic(err)
 	}
-
-	return KNativeClient{client: servingClient}
+	networkingClient, err := networkingClientSet.NewForConfig(config)
+	if err != nil {
+		panic(err)
+	}
+	return KNativeClient{servingClient: servingClient, networkingClient: networkingClient}
 }
 
 func (kNativeClient *KNativeClient) Services(namespace string) (*v1alpha1.ServiceList, error) {
-	return kNativeClient.client.Services(namespace).List(v1.ListOptions{})
+	return kNativeClient.servingClient.Services(namespace).List(v1.ListOptions{})
 }
 
-func ServiceHTTP2Enabled(service v1alpha1.Service) bool {
-
-	container := service.Spec.Template.Spec.GetContainer()
-	if len(container.Ports) > 0 {
-		if container.Ports[0].Name == "http2" || container.Ports[0].Name == "h2c" {
-			return true
-		}
-	}
-	return false
+func (kNativeClient *KNativeClient) ClusterIngresses() (*networkingv1alpha1.ClusterIngressList, error) {
+	return kNativeClient.networkingClient.ClusterIngresses().List(v1.ListOptions{})
 }
 
-func HTTPPortForEndpointSubset(service v1alpha1.Service, subset corev1.EndpointSubset) (uint32, error) {
+// Pushes an event to the "events" channel received when theres a change in a ClusterIngress is added/deleted/updated.
+func (kNativeClient *KNativeClient) WatchChangesInClusterIngress(namespace string, events chan<- string, stopChan <-chan struct{}) {
 
-	desiredPortName := ""
-	// This is here for debug and development purpose, remove once we are sure this kinda works.
-	if len(service.Spec.Template.Spec.GetContainer().Ports) > 1 {
-		log.Infof("service %s has more than 1 container specified", service.Name)
-	}
+	restClient := kNativeClient.networkingClient.RESTClient()
 
-	if ServiceHTTP2Enabled(service) {
-		desiredPortName = "http2"
-	}
-
-	switch desiredPortName {
-	case "http2":
-		for _, port := range subset.Ports {
-			if port.Name == "http2" || port.Name == "h2c" {
-				return uint32(port.Port), nil
-			}
-		}
-	default:
-		for _, port := range subset.Ports {
-			if port.Name == "http" || port.Name == "http1" {
-				return uint32(port.Port), nil
-			}
-		}
-
-	}
-
-	return 0, fmt.Errorf("http port not found")
-}
-
-func DomainsFromService(service *v1alpha1.Service) ([]string, error) {
-	var domains []string
-
-	if service.Status.URL == nil {
-		return nil, fmt.Errorf("url is empty")
-	}
-	domains = append(domains, fmt.Sprintf("%s.%s", service.Name, service.Namespace))
-	domains = append(domains, fmt.Sprintf("%s.%s.svc", service.Name, service.Namespace))
-	domains = append(domains, service.Status.URL.Host)
-	domains = append(domains, service.Status.Address.GetURL().Host)
-
-	return domains, nil
-}
-
-// Pushes an event to the "events" channel received when an serving is added/deleted/updated.
-func (kNativeClient *KNativeClient) WatchChangesInServices(namespace string, events chan<- string, stopChan <-chan struct{}) {
-	restClient := kNativeClient.client.RESTClient()
-
-	watchlist := cache.NewListWatchFromClient(restClient, "services", namespace,
+	watchlist := cache.NewListWatchFromClient(restClient, "clusteringresses", namespace,
 		fields.Everything())
 
 	_, controller := cache.NewInformer(
 		watchlist,
-		&v1alpha1.Service{},
-		time.Second*1,
+		&networkingv1alpha1.ClusterIngress{},
+		time.Second*30, //TODO: Review resync time and adjust.
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				events <- "change"

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -66,6 +66,10 @@ func (kubernetesClient *KubernetesClient) EndpointsForRevision(namespace string,
 	return kubernetesClient.client.CoreV1().Endpoints(namespace).List(listOptions)
 }
 
+func (kubernetesClient *KubernetesClient) ServiceForRevision(namespace string, revisionName string) (*v1.Service, error) {
+	return kubernetesClient.client.CoreV1().Services(namespace).Get(revisionName, meta_v1.GetOptions{})
+}
+
 // Pushes an event to the "events" channel received when an endpoint is added/deleted/updated.
 func (kubernetesClient *KubernetesClient) WatchChangesInEndpoints(namespace string, events chan<- string, stopChan <-chan struct{}) {
 	restClient := kubernetesClient.client.CoreV1().RESTClient()
@@ -76,7 +80,7 @@ func (kubernetesClient *KubernetesClient) WatchChangesInEndpoints(namespace stri
 	_, controller := cache.NewInformer(
 		watchlist,
 		&v1.Endpoints{},
-		time.Second*1,
+		time.Second*30,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				events <- "change"


### PR DESCRIPTION
* Removes watchers for service.
* Adds watcher for ClusterIngress.
* Adds support for creating an envoy Snapshot from a ClusterIngress object.