### PR TITLE
Allows to setup a local knative + kourier environment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,5 +21,8 @@ build: ## Builds kourier binary, outputs binary to ./build
 docker-build: ## Builds kourier docker, tagged by default as 3scale-kourier:test
 	docker build -t 3scale-kourier:test ./
 
+local-setup: ## Builds and deploys kourier locally in a k3s cluster with knative, forwards the local 8080 to kourier/envoy
+	./utils/setup.sh
+
 help: ## Print this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-39s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/cmd/kourier/main.go
+++ b/cmd/kourier/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	log "github.com/sirupsen/logrus"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"kourier/pkg/envoy"
 	"kourier/pkg/knative"
 	"kourier/pkg/kubernetes"
-	log "github.com/sirupsen/logrus"
-	"knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"os"
 )
 

--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: 3scale-kourier
+  namespace: knative-serving
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
@@ -73,6 +74,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: 3scale-kourier
+  namespace: knative-serving
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -91,6 +93,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kourier
+  namespace: knative-serving
 spec:
   ports:
     - port: 8080
@@ -106,6 +109,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kourier-bootstrap
+  namespace: knative-serving
 data:
   envoy-bootstrap.yaml: |
     admin:

--- a/utils/setup.sh
+++ b/utils/setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+if ! command -v k3d >/dev/null; then
+  echo "k3d binary not in path, install with: curl -s https://raw.githubusercontent.com/rancher/k3d/master/install.sh | bash"
+  exit 1
+fi
+
+tag="test_$(git rev-parse --abbrev-ref HEAD)"
+
+docker build -t 3scale-kourier:"$tag" ./
+
+k3d d --name=kourier-integration || true
+
+k3d c --name kourier-integration
+sleep 60
+export KUBECONFIG="$(k3d get-kubeconfig --name='kourier-integration')"
+k3d import-images 3scale-kourier:"$tag" --name='kourier-integration'
+
+kubectl apply -f https://github.com/knative/serving/releases/download/v0.9.0/serving.yaml || true
+kubectl scale deployment traefik --replicas=0 -n kube-system
+kubectl apply -f deploy/kourier-knative.yaml
+kubectl patch deployment 3scale-kourier -n knative-serving --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier\",\"image\": \"3scale-kourier:$tag\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
+
+retries=0
+while [[ $(kubectl get pods -n knative-serving -l app=3scale-kourier -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+  echo "Waiting for kourier pod to be ready "
+  sleep 10
+  if [ $retries -ge 7 ]; then
+    echo "timedout waiting for kourier pod"
+    exit 1
+  fi
+  retries=$[$retries+1]
+done
+
+kubectl port-forward --namespace knative-serving $(kubectl get pod -n knative-serving -l "app=3scale-kourier" --output=jsonpath="{.items[0].metadata.name}") 8080:8080


### PR DESCRIPTION
* Deploys a kubernetes cluster in docker (k3s with k3d)
* Deploys knative 0.9.0 
* Builds a new kourier container image and copies it into the k3s cluster (no remote registry needed). 
* Exposes kourier 8080 port locally. 
 