### PR TITLE
Add test for Ingress with traffic split

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@ docker-build: ## Builds kourier docker, tagged by default as 3scale-kourier:test
 local-setup: ## Builds and deploys kourier locally in a k3s cluster with knative, forwards the local 8080 to kourier/envoy
 	./utils/setup.sh
 
+test: test-unit test-integration ## Runs all the tests
+
+test-unit: ## Runs unit tests
+	go test $(shell go list ./... | grep -v kourier/test)
+
 test-integration: local-setup ## Runs integration tests
 	go test test/* -args -kubeconfig="$(shell k3d get-kubeconfig --name='kourier-integration')"
 

--- a/pkg/envoy/caches.go
+++ b/pkg/envoy/caches.go
@@ -1,0 +1,359 @@
+package envoy
+
+import (
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	accesslogv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
+	httpconnectionmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	"github.com/envoyproxy/go-control-plane/pkg/cache"
+	"github.com/envoyproxy/go-control-plane/pkg/util"
+	"github.com/gogo/protobuf/types"
+	log "github.com/sirupsen/logrus"
+	kubev1 "k8s.io/api/core/v1"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"strconv"
+	"time"
+)
+
+type Caches struct {
+	endpoints []cache.Resource
+	clusters  []cache.Resource
+	routes    []cache.Resource
+	listeners []cache.Resource
+}
+
+type KubeClient interface {
+	EndpointsForRevision(namespace string, serviceName string) (*kubev1.EndpointsList, error)
+	ServiceForRevision(namespace string, serviceName string) (*kubev1.Service, error)
+}
+
+func CachesForClusterIngresses(Ingresses []v1alpha1.IngressAccessor, kubeClient KubeClient) Caches {
+	var virtualHosts []*route.VirtualHost
+	var routeCache []cache.Resource
+	var clusterCache []cache.Resource
+
+	for i, ingress := range Ingresses {
+
+		routeName := getRouteName(ingress)
+		routeNamespace := getRouteNamespace(ingress)
+
+		log.WithFields(log.Fields{"name": routeName, "namespace": routeNamespace}).Info("Knative Ingress found")
+
+		for _, rule := range ingress.GetSpec().Rules {
+
+			var ruleRoute []*route.Route
+			domains := rule.Hosts
+
+			for _, httpPath := range rule.HTTP.Paths {
+
+				path := "/"
+				if httpPath.Path != "" {
+					path = httpPath.Path
+				}
+
+				var wrs []*route.WeightedCluster_ClusterWeight
+
+				for _, split := range httpPath.Splits {
+
+					headersSplit := split.AppendHeaders
+
+					endpointList, err := kubeClient.EndpointsForRevision(split.ServiceNamespace, split.ServiceName)
+
+					if err != nil {
+						log.Errorf("%s", err)
+						break
+					}
+					service, err := kubeClient.ServiceForRevision(split.ServiceNamespace, split.ServiceName)
+
+					if err != nil {
+						log.Errorf("%s", err)
+						break
+					}
+
+					var targetPort int32
+					http2 := false
+					for _, port := range service.Spec.Ports {
+						if port.Port == split.ServicePort.IntVal || port.Name == split.ServicePort.StrVal {
+							targetPort = port.TargetPort.IntVal
+							http2 = port.Name == "http2" || port.Name == "h2c"
+						}
+					}
+
+					privateLbEndpoints, publicLbEndpoints := lbEndpointsForKubeEndpoints(endpointList, targetPort)
+
+					connectTimeout := 5 * time.Second
+					cluster := clusterForRevision(split.ServiceName, connectTimeout, privateLbEndpoints, publicLbEndpoints, http2, path)
+					clusterCache = append(clusterCache, &cluster)
+
+					weightedCluster := weightedCluster(split.ServiceName, uint32(split.Percent), path, headersSplit)
+
+					wrs = append(wrs, &weightedCluster)
+
+				}
+
+				r := createRouteForRevision(routeName, i, &httpPath, wrs)
+
+				ruleRoute = append(ruleRoute, &r)
+				routeCache = append(routeCache, &r)
+
+			}
+
+			virtualHost := route.VirtualHost{
+				Name:    routeName,
+				Domains: domains,
+				Routes:  ruleRoute,
+			}
+
+			virtualHosts = append(virtualHosts, &virtualHost)
+		}
+
+	}
+
+	manager := httpConnectionManager(virtualHosts)
+	l := envoyListener(&manager)
+	listenerCache := []cache.Resource{&l}
+
+	return Caches{
+		endpoints: []cache.Resource{},
+		clusters:  clusterCache,
+		routes:    routeCache,
+		listeners: listenerCache,
+	}
+}
+
+func getRouteNamespace(ingress v1alpha1.IngressAccessor) string {
+	return ingress.GetLabels()["serving.knative.dev/routeNamespace"]
+}
+
+func getRouteName(ingress v1alpha1.IngressAccessor) string {
+	return ingress.GetLabels()["serving.knative.dev/route"]
+}
+
+func lbEndpointsForKubeEndpoints(kubeEndpoints *kubev1.EndpointsList, targetPort int32) (privateLbEndpoints []*endpoint.LbEndpoint, publicLbEndpoints []*endpoint.LbEndpoint) {
+
+	for _, kubeEndpoint := range kubeEndpoints.Items {
+
+		for _, subset := range kubeEndpoint.Subsets {
+
+			for _, address := range subset.Addresses {
+
+				serviceEndpoint := &core.Address{
+					Address: &core.Address_SocketAddress{
+						SocketAddress: &core.SocketAddress{
+							Protocol: core.TCP,
+							Address:  address.IP,
+							PortSpecifier: &core.SocketAddress_PortValue{
+								PortValue: uint32(targetPort),
+							},
+							Ipv4Compat: true,
+						},
+					},
+				}
+
+				lbEndpoint := endpoint.LbEndpoint{
+					HostIdentifier: &endpoint.LbEndpoint_Endpoint{
+						Endpoint: &endpoint.Endpoint{
+							Address: serviceEndpoint,
+						},
+					},
+				}
+
+				if kubeEndpoint.Labels["networking.internal.knative.dev/serviceType"] == "Private" {
+					privateLbEndpoints = append(privateLbEndpoints, &lbEndpoint)
+				} else if kubeEndpoint.Labels["networking.internal.knative.dev/serviceType"] == "Public" {
+					publicLbEndpoints = append(publicLbEndpoints, &lbEndpoint)
+				}
+			}
+		}
+	}
+
+	return privateLbEndpoints, publicLbEndpoints
+}
+
+func createRouteForRevision(routeName string, i int, httpPath *v1alpha1.HTTPIngressPath, wrs []*route.WeightedCluster_ClusterWeight) route.Route {
+	path := "/"
+	if httpPath.Path != "" {
+		path = httpPath.Path
+	}
+
+	var routeTimeout time.Duration
+	if httpPath.Timeout != nil {
+		routeTimeout = httpPath.Timeout.Duration
+	}
+
+	r := route.Route{
+		Name: routeName + "_" + strconv.Itoa(i),
+		Match: &route.RouteMatch{
+			PathSpecifier: &route.RouteMatch_Prefix{
+				Prefix: path,
+			},
+		},
+		Action: &route.Route_Route{Route: &route.RouteAction{
+			ClusterSpecifier: &route.RouteAction_WeightedClusters{
+				WeightedClusters: &route.WeightedCluster{
+					Clusters: wrs,
+				},
+			},
+			Timeout:     &routeTimeout,
+			RetryPolicy: createRetryPolicyForRoute(httpPath),
+		}},
+		RequestHeadersToAdd: headersToAdd(httpPath.AppendHeaders),
+	}
+
+	return r
+}
+
+func weightedCluster(revisionName string, trafficPerc uint32, path string, headers map[string]string) route.WeightedCluster_ClusterWeight {
+	return route.WeightedCluster_ClusterWeight{
+		Name: revisionName + path,
+		Weight: &types.UInt32Value{
+			Value: trafficPerc,
+		},
+		RequestHeadersToAdd: headersToAdd(headers),
+	}
+}
+
+func headersToAdd(headers map[string]string) []*core.HeaderValueOption {
+	var res []*core.HeaderValueOption
+
+	for headerName, headerVal := range headers {
+		header := core.HeaderValueOption{
+			Header: &core.HeaderValue{
+				Key:   headerName,
+				Value: headerVal,
+			},
+			Append: &types.BoolValue{
+				Value: true,
+			},
+		}
+
+		res = append(res, &header)
+
+	}
+
+	return res
+}
+
+func createRetryPolicyForRoute(httpPath *v1alpha1.HTTPIngressPath) *route.RetryPolicy {
+	attempts := 0
+	var perTryTimeout time.Duration
+	if httpPath.Retries != nil {
+		attempts = httpPath.Retries.Attempts
+
+		if httpPath.Retries.PerTryTimeout != nil {
+			perTryTimeout = httpPath.Retries.PerTryTimeout.Duration
+		}
+	}
+
+	if attempts > 0 {
+		return &route.RetryPolicy{
+			RetryOn: "5xx",
+			NumRetries: &types.UInt32Value{
+				Value: uint32(attempts),
+			},
+			PerTryTimeout: &perTryTimeout,
+		}
+	} else {
+		return nil
+	}
+}
+
+func clusterForRevision(revisionName string, connectTimeout time.Duration, privateLbEndpoints, publicLbEndpoints []*endpoint.LbEndpoint, http2 bool, path string) v2.Cluster {
+
+	cluster := v2.Cluster{
+		Name: revisionName + path,
+		ClusterDiscoveryType: &v2.Cluster_Type{
+			Type: v2.Cluster_STRICT_DNS,
+		},
+		ConnectTimeout: &connectTimeout,
+		LoadAssignment: &v2.ClusterLoadAssignment{
+			ClusterName: revisionName + path,
+			Endpoints: []*endpoint.LocalityLbEndpoints{
+				{
+					LbEndpoints: publicLbEndpoints,
+					Priority:    1,
+				},
+				{
+					LbEndpoints: privateLbEndpoints,
+					Priority:    0,
+				},
+			},
+		},
+	}
+
+	if http2 {
+		cluster.Http2ProtocolOptions = &core.Http2ProtocolOptions{}
+	}
+
+	return cluster
+}
+
+func envoyListener(httpConnectionManager *httpconnectionmanagerv2.HttpConnectionManager) v2.Listener {
+	pbst, err := util.MessageToStruct(httpConnectionManager)
+	if err != nil {
+		panic(err)
+	}
+
+	return v2.Listener{
+		Name: "listener_0",
+		Address: &core.Address{
+			Address: &core.Address_SocketAddress{
+				SocketAddress: &core.SocketAddress{
+					Protocol: core.TCP,
+					Address:  "0.0.0.0",
+					PortSpecifier: &core.SocketAddress_PortValue{
+						PortValue: uint32(8080),
+					},
+				},
+			},
+		},
+		FilterChains: []*listener.FilterChain{{
+			Filters: []*listener.Filter{{
+				Name:       util.HTTPConnectionManager,
+				ConfigType: &listener.Filter_Config{Config: pbst},
+			}},
+		}},
+	}
+}
+
+func httpConnectionManager(virtualHosts []*route.VirtualHost) httpconnectionmanagerv2.HttpConnectionManager {
+	return httpconnectionmanagerv2.HttpConnectionManager{
+		CodecType:  httpconnectionmanagerv2.AUTO,
+		StatPrefix: "ingress_http",
+		RouteSpecifier: &httpconnectionmanagerv2.HttpConnectionManager_RouteConfig{
+			RouteConfig: &v2.RouteConfiguration{
+				Name:         "local_route",
+				VirtualHosts: virtualHosts,
+			},
+		},
+		HttpFilters: []*httpconnectionmanagerv2.HttpFilter{
+			{
+				Name: util.Router,
+			},
+		},
+
+		AccessLog: accessLogs(),
+	}
+}
+
+// Outputs to /dev/stdout using the default format
+func accessLogs() []*accesslogv2.AccessLog {
+	accessLogConfigFields := make(map[string]*types.Value)
+	accessLogConfigFields["path"] = &types.Value{
+		Kind: &types.Value_StringValue{
+			StringValue: "/dev/stdout",
+		},
+	}
+
+	return []*accesslogv2.AccessLog{
+		{
+			Name: "envoy.file_access_log",
+			ConfigType: &accesslogv2.AccessLog_Config{
+				Config: &types.Struct{Fields: accessLogConfigFields},
+			},
+		},
+	}
+}

--- a/pkg/envoy/caches_test.go
+++ b/pkg/envoy/caches_test.go
@@ -1,0 +1,188 @@
+package envoy
+
+import (
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/envoyproxy/go-control-plane/pkg/cache"
+	"gotest.tools/assert"
+	kubev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"testing"
+)
+
+// Tests that when there is a traffic split defined in the ingress:
+// - Creates a route with weighted clusters defined.
+// - There's one weighted cluster for each traffic split and each contains:
+// 		- The traffic percentage.
+//		- The headers to add (namespace and revision name).
+//		- The cluster name, based on the revision name plus the path.
+// - The weighted clusters exists also in the clusters cache with the same
+//   name.
+//
+// Note: for now, the name of the cluster is the name of the revision plus the
+// path. That might change in the future.
+func TestTrafficSplits(t *testing.T) {
+	ingress := v1alpha1.Ingress{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Ingress",
+			APIVersion: "networking.internal.knative.dev/v1alpha1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "hello-world",
+		},
+		Spec: v1alpha1.IngressSpec{
+			Rules: []v1alpha1.IngressRule{
+				{
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{
+							{
+								Splits: []v1alpha1.IngressBackendSplit{
+									{
+										IngressBackend: v1alpha1.IngressBackend{
+											ServiceNamespace: "default",
+											ServiceName:      "hello-world-rev1",
+											ServicePort: intstr.IntOrString{
+												Type:   intstr.Int,
+												IntVal: 80,
+											},
+										},
+										Percent: 60,
+										AppendHeaders: map[string]string{
+											"Knative-Serving-Namespace": "default",
+											"Knative-Serving-Revision":  "hello-world-rev1",
+										},
+									},
+									{
+										IngressBackend: v1alpha1.IngressBackend{
+											ServiceNamespace: "default",
+											ServiceName:      "hello-world-rev2",
+											ServicePort: intstr.IntOrString{
+												Type:   intstr.Int,
+												IntVal: 80,
+											},
+										},
+										Percent: 40,
+										AppendHeaders: map[string]string{
+											"Knative-Serving-Namespace": "default",
+											"Knative-Serving-Revision":  "hello-world-rev2",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: v1alpha1.IngressStatus{},
+	}
+
+	// Check that there is one route in the result
+	caches := CachesForClusterIngresses(
+		[]v1alpha1.IngressAccessor{v1alpha1.IngressAccessor(&ingress)},
+		newMockedKubeClient(),
+	)
+	assert.Equal(t, 1, len(caches.routes))
+
+	// Check that there are 2 weighted clusters for the route
+	envoyRoute := caches.routes[0].(*route.Route)
+	weightedClusters := envoyRoute.GetRoute().GetWeightedClusters().Clusters
+	assert.Equal(t, 2, len(weightedClusters))
+
+	// Check the first weighted cluster
+	assertWeightedClusterCorrect(
+		t,
+		weightedClusters[0],
+		"hello-world-rev1/",
+		uint32(60),
+		map[string]string{
+			"Knative-Serving-Namespace": "default",
+			"Knative-Serving-Revision":  "hello-world-rev1",
+		},
+	)
+
+	// Check the second weighted cluster
+	assertWeightedClusterCorrect(
+		t,
+		weightedClusters[1],
+		"hello-world-rev2/",
+		uint32(40),
+		map[string]string{
+			"Knative-Serving-Namespace": "default",
+			"Knative-Serving-Revision":  "hello-world-rev2",
+		},
+	)
+
+	// Check the clusters cache
+	assert.Equal(
+		t,
+		true,
+		clustersExist([]string{"hello-world-rev1/", "hello-world-rev2/"}, caches.clusters),
+	)
+}
+
+type mockedKubeClient struct{}
+
+func (kubeClient *mockedKubeClient) EndpointsForRevision(namespace string, serviceName string) (*kubev1.EndpointsList, error) {
+	list := kubev1.EndpointsList{
+		Items: []kubev1.Endpoints{},
+	}
+
+	return &list, nil
+}
+
+func (kubeClient *mockedKubeClient) ServiceForRevision(namespace string, serviceName string) (*kubev1.Service, error) {
+	service := kubev1.Service{
+		Spec: kubev1.ServiceSpec{},
+	}
+	return &service, nil
+}
+
+func newMockedKubeClient() *mockedKubeClient {
+	return new(mockedKubeClient)
+}
+
+func clustersExist(names []string, clustersCache []cache.Resource) bool {
+	// Cast Resources to Clusters
+	var clusters []*v2.Cluster
+	for _, cacheCluster := range clustersCache {
+		clusters = append(clusters, cacheCluster.(*v2.Cluster))
+	}
+
+	// Create map that contains names that are present
+	present := make(map[string]bool)
+	for _, cacheCluster := range clusters {
+		present[cacheCluster.Name] = true
+	}
+
+	// Verify if the received names are present
+	for _, name := range names {
+		if !present[name] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Checks whether the weightedCluster received has the received name, traffic
+// percentage and headers to add
+func assertWeightedClusterCorrect(t *testing.T,
+	weightedCluster *route.WeightedCluster_ClusterWeight,
+	name string,
+	trafficPerc uint32,
+	headersToAdd map[string]string) {
+
+	assert.Equal(t, name, weightedCluster.Name)
+
+	assert.Equal(t, trafficPerc, weightedCluster.Weight.Value)
+
+	// Collect headers for easier comparison
+	clusterHeaders := make(map[string]string)
+	for _, header := range weightedCluster.RequestHeadersToAdd {
+		clusterHeaders[header.Header.Key] = header.Header.Value
+	}
+	assert.DeepEqual(t, clusterHeaders, headersToAdd)
+}

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -5,27 +5,17 @@ import (
 	"fmt"
 	envoyv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	accesslogv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
 	xds "github.com/envoyproxy/go-control-plane/pkg/server"
-	"github.com/envoyproxy/go-control-plane/pkg/util"
-	"github.com/gogo/protobuf/types"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-	kubev1 "k8s.io/api/core/v1"
 	v1alpha12 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"kourier/pkg/knative"
 	"kourier/pkg/kubernetes"
 	"net"
 	"net/http"
-	"strconv"
-	"time"
 )
 
 const (
@@ -120,98 +110,21 @@ func (envoyXdsServer *EnvoyXdsServer) RunGateway() {
 }
 
 func (envoyXdsServer *EnvoyXdsServer) SetSnapshotForClusterIngresses(nodeId string, Ingresses []v1alpha12.IngressAccessor) {
-	var virtualHosts []*route.VirtualHost
-	var routeCache []cache.Resource
-	var clusterCache []cache.Resource
-
-	for i, ingress := range Ingresses {
-
-		routeName := getRouteName(ingress)
-		routeNamespace := getRouteNamespace(ingress)
-
-		log.WithFields(log.Fields{"name": routeName, "namespace": routeNamespace}).Info("Knative Ingress found")
-
-		for _, rule := range ingress.GetSpec().Rules {
-
-			var ruleRoute []*route.Route
-			domains := rule.Hosts
-
-			for _, httpPath := range rule.HTTP.Paths {
-
-				path := "/"
-				if httpPath.Path != "" {
-					path = httpPath.Path
-				}
-
-				var wrs []*route.WeightedCluster_ClusterWeight
-
-				for _, split := range httpPath.Splits {
-
-					headersSplit := split.AppendHeaders
-
-					endpointList, err := envoyXdsServer.kubeClient.EndpointsForRevision(split.ServiceNamespace, split.ServiceName)
-
-					if err != nil {
-						log.Errorf("%s", err)
-						break
-					}
-					service, err := envoyXdsServer.kubeClient.ServiceForRevision(split.ServiceNamespace, split.ServiceName)
-
-					if err != nil {
-						log.Errorf("%s", err)
-						break
-					}
-
-					var targetPort int32
-					http2 := false
-					for _, port := range service.Spec.Ports {
-						if port.Port == split.ServicePort.IntVal || port.Name == split.ServicePort.StrVal {
-							targetPort = port.TargetPort.IntVal
-							http2 = port.Name == "http2" || port.Name == "h2c"
-						}
-					}
-
-					privateLbEndpoints, publicLbEndpoints := lbEndpointsForKubeEndpoints(endpointList, targetPort)
-
-					connectTimeout := 5 * time.Second
-					cluster := clusterForRevision(split.ServiceName, connectTimeout, privateLbEndpoints, publicLbEndpoints, http2, path)
-					clusterCache = append(clusterCache, &cluster)
-
-					weightedCluster := weightedCluster(split.ServiceName, uint32(split.Percent), path, headersSplit)
-
-					wrs = append(wrs, &weightedCluster)
-
-				}
-
-				r := createRouteForRevision(routeName, i, &httpPath, wrs)
-
-				ruleRoute = append(ruleRoute, &r)
-				routeCache = append(routeCache, &r)
-
-			}
-
-			virtualHost := route.VirtualHost{
-				Name:    routeName,
-				Domains: domains,
-				Routes:  ruleRoute,
-			}
-
-			virtualHosts = append(virtualHosts, &virtualHost)
-		}
-
-	}
-
-	manager := httpConnectionManager(virtualHosts)
-	l := envoyListener(&manager)
-	listenerCache := []cache.Resource{&l}
-
 	snapshotVersion, errUUID := uuid.NewUUID()
 	if errUUID != nil {
 		log.Error(errUUID)
 		return
 	}
 
-	snapshot := cache.NewSnapshot(snapshotVersion.String(), nil, clusterCache, routeCache, listenerCache)
+	caches := CachesForClusterIngresses(Ingresses, &envoyXdsServer.kubeClient)
+
+	snapshot := cache.NewSnapshot(
+		snapshotVersion.String(),
+		caches.endpoints,
+		caches.clusters,
+		caches.routes,
+		caches.listeners,
+	)
 
 	err := envoyXdsServer.snapshotCache.SetSnapshot(nodeId, snapshot)
 
@@ -256,238 +169,4 @@ func markIngressReady(ingress v1alpha12.IngressAccessor, envoyXdsServer *EnvoyXd
 		}
 	}
 	return nil
-}
-
-func createRouteForRevision(routeName string, i int, httpPath *v1alpha12.HTTPIngressPath, wrs []*route.WeightedCluster_ClusterWeight) route.Route {
-	path := "/"
-	if httpPath.Path != "" {
-		path = httpPath.Path
-	}
-
-	var routeTimeout time.Duration
-	if httpPath.Timeout != nil {
-		routeTimeout = httpPath.Timeout.Duration
-	}
-
-	r := route.Route{
-		Name: routeName + "_" + strconv.Itoa(i),
-		Match: &route.RouteMatch{
-			PathSpecifier: &route.RouteMatch_Prefix{
-				Prefix: path,
-			},
-		},
-		Action: &route.Route_Route{Route: &route.RouteAction{
-			ClusterSpecifier: &route.RouteAction_WeightedClusters{
-				WeightedClusters: &route.WeightedCluster{
-					Clusters: wrs,
-				},
-			},
-			Timeout:     &routeTimeout,
-			RetryPolicy: createRetryPolicyForRoute(httpPath),
-		}},
-		RequestHeadersToAdd: headersToAdd(httpPath.AppendHeaders),
-	}
-
-	return r
-}
-
-func headersToAdd(headers map[string]string) []*core.HeaderValueOption {
-	var res []*core.HeaderValueOption
-
-	for headerName, headerVal := range headers {
-		header := core.HeaderValueOption{
-			Header: &core.HeaderValue{
-				Key:   headerName,
-				Value: headerVal,
-			},
-			Append: &types.BoolValue{
-				Value: true,
-			},
-		}
-
-		res = append(res, &header)
-
-	}
-
-	return res
-}
-
-func createRetryPolicyForRoute(httpPath *v1alpha12.HTTPIngressPath) *route.RetryPolicy {
-	attempts := 0
-	var perTryTimeout time.Duration
-	if httpPath.Retries != nil {
-		attempts = httpPath.Retries.Attempts
-
-		if httpPath.Retries.PerTryTimeout != nil {
-			perTryTimeout = httpPath.Retries.PerTryTimeout.Duration
-		}
-	}
-
-	if attempts > 0 {
-		return &route.RetryPolicy{
-			RetryOn: "5xx",
-			NumRetries: &types.UInt32Value{
-				Value: uint32(attempts),
-			},
-			PerTryTimeout: &perTryTimeout,
-		}
-	} else {
-		return nil
-	}
-}
-
-func getRouteNamespace(ingress v1alpha12.IngressAccessor) string {
-	return ingress.GetLabels()["serving.knative.dev/routeNamespace"]
-}
-
-func getRouteName(ingress v1alpha12.IngressAccessor) string {
-	return ingress.GetLabels()["serving.knative.dev/route"]
-}
-
-func lbEndpointsForKubeEndpoints(kubeEndpoints *kubev1.EndpointsList, targetPort int32) (privateLbEndpoints []*endpoint.LbEndpoint, publicLbEndpoints []*endpoint.LbEndpoint) {
-
-	for _, kubeEndpoint := range kubeEndpoints.Items {
-
-		for _, subset := range kubeEndpoint.Subsets {
-
-			for _, address := range subset.Addresses {
-
-				serviceEndpoint := &core.Address{
-					Address: &core.Address_SocketAddress{
-						SocketAddress: &core.SocketAddress{
-							Protocol: core.TCP,
-							Address:  address.IP,
-							PortSpecifier: &core.SocketAddress_PortValue{
-								PortValue: uint32(targetPort),
-							},
-							Ipv4Compat: true,
-						},
-					},
-				}
-
-				lbEndpoint := endpoint.LbEndpoint{
-					HostIdentifier: &endpoint.LbEndpoint_Endpoint{
-						Endpoint: &endpoint.Endpoint{
-							Address: serviceEndpoint,
-						},
-					},
-				}
-
-				if kubeEndpoint.Labels["networking.internal.knative.dev/serviceType"] == "Private" {
-					privateLbEndpoints = append(privateLbEndpoints, &lbEndpoint)
-				} else if kubeEndpoint.Labels["networking.internal.knative.dev/serviceType"] == "Public" {
-					publicLbEndpoints = append(publicLbEndpoints, &lbEndpoint)
-				}
-			}
-		}
-	}
-
-	return privateLbEndpoints, publicLbEndpoints
-}
-
-func clusterForRevision(revisionName string, connectTimeout time.Duration, privateLbEndpoints, publicLbEndpoints []*endpoint.LbEndpoint, http2 bool, path string) envoyv2.Cluster {
-
-	cluster := envoyv2.Cluster{
-		Name: revisionName + path,
-		ClusterDiscoveryType: &envoyv2.Cluster_Type{
-			Type: envoyv2.Cluster_STRICT_DNS,
-		},
-		ConnectTimeout: &connectTimeout,
-		LoadAssignment: &envoyv2.ClusterLoadAssignment{
-			ClusterName: revisionName + path,
-			Endpoints: []*endpoint.LocalityLbEndpoints{
-				{
-					LbEndpoints: publicLbEndpoints,
-					Priority:    1,
-				},
-				{
-					LbEndpoints: privateLbEndpoints,
-					Priority:    0,
-				},
-			},
-		},
-	}
-
-	if http2 {
-		cluster.Http2ProtocolOptions = &core.Http2ProtocolOptions{}
-	}
-
-	return cluster
-}
-
-func weightedCluster(revisionName string, trafficPerc uint32, path string, headers map[string]string) route.WeightedCluster_ClusterWeight {
-	return route.WeightedCluster_ClusterWeight{
-		Name: revisionName + path,
-		Weight: &types.UInt32Value{
-			Value: trafficPerc,
-		},
-		RequestHeadersToAdd: headersToAdd(headers),
-	}
-}
-
-func httpConnectionManager(virtualHosts []*route.VirtualHost) v2.HttpConnectionManager {
-	return v2.HttpConnectionManager{
-		CodecType:  v2.AUTO,
-		StatPrefix: "ingress_http",
-		RouteSpecifier: &v2.HttpConnectionManager_RouteConfig{
-			RouteConfig: &envoyv2.RouteConfiguration{
-				Name:         "local_route",
-				VirtualHosts: virtualHosts,
-			},
-		},
-		HttpFilters: []*v2.HttpFilter{
-			{
-				Name: util.Router,
-			},
-		},
-
-		AccessLog: accessLogs(),
-	}
-}
-
-// Outputs to /dev/stdout using the default format
-func accessLogs() []*accesslogv2.AccessLog {
-	accessLogConfigFields := make(map[string]*types.Value)
-	accessLogConfigFields["path"] = &types.Value{
-		Kind: &types.Value_StringValue{
-			StringValue: "/dev/stdout",
-		},
-	}
-
-	return []*accesslogv2.AccessLog{
-		{
-			Name: "envoy.file_access_log",
-			ConfigType: &accesslogv2.AccessLog_Config{
-				Config: &types.Struct{Fields: accessLogConfigFields},
-			},
-		},
-	}
-}
-
-func envoyListener(httpConnectionManager *v2.HttpConnectionManager) envoyv2.Listener {
-	pbst, err := util.MessageToStruct(httpConnectionManager)
-	if err != nil {
-		panic(err)
-	}
-
-	return envoyv2.Listener{
-		Name: "listener_0",
-		Address: &core.Address{
-			Address: &core.Address_SocketAddress{
-				SocketAddress: &core.SocketAddress{
-					Protocol: core.TCP,
-					Address:  "0.0.0.0",
-					PortSpecifier: &core.SocketAddress_PortValue{
-						PortValue: uint32(8080),
-					},
-				},
-			},
-		},
-		FilterChains: []*listener.FilterChain{{
-			Filters: []*listener.Filter{{
-				Name:       util.HTTPConnectionManager,
-				ConfigType: &listener.Filter_Config{Config: pbst},
-			}},
-		}},
-	}
 }


### PR DESCRIPTION
This PR adds unit tests for Ingresses with traffic splits. There are a couple of things that I needed to do first:
- Create a new target in the Makefile so we can run unit and integration tests separately.
- Split the logic in the Envoy package. All the logic to generate caches has been extracted to `caches.go`. That allows us to test separately just the process of creating all the caches needed for an Envoy config snapshot.

We'll need to add more unit tests, but before doing so, I wanted to agree on the way we are going to test this. That's why I just added one test.