### PR TITLE
Add initial basic config for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # Golang CircleCI 2.0 configuration file
 #
 # Check https://circleci.com/docs/2.0/language-go/ for more details
-version: 2
+version: 2.1
 jobs:
   build:
     machine:
@@ -17,14 +17,7 @@ jobs:
 
       # Remove existing go and install 1.13.
       - run: sudo apt-get remove golang-go && sudo rm -rf /usr/local/go
-      - run: wget https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz
-      - run: sudo tar -C /usr/local -xzf go1.13.1.linux-amd64.tar.gz
-      - run: export PATH=$PATH:/usr/local/go/bin
-
-      - run: curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl
-      - run: chmod +x ./kubectl
-      - run: sudo mv ./kubectl /usr/local/bin/kubectl
-
-      - run: curl -s https://raw.githubusercontent.com/rancher/k3d/master/install.sh | bash
-
-      - run: make test
+      - run: wget https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz -O /tmp/go1.13.1.linux-amd64.tar.gz
+      - run: sudo tar -C /usr/local -xzf /tmp/go1.13.1.linux-amd64.tar.gz
+      - run: sudo snap install microk8s --classic
+      - run: PATH=$PATH:/usr/local/go/bin:/snap/bin/ make test-circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+# Golang CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-go/ for more details
+version: 2
+jobs:
+  build:
+    machine:
+      image: ubuntu-1604:201903-01
+
+    #### TEMPLATE_NOTE: go expects specific checkout path representing url
+    #### expecting it in the form of
+    ####   /go/src/github.com/circleci/go-tool
+    ####   /go/src/bitbucket.org/circleci/go-tool
+    working_directory: /home/circleci/go/src/github.com/3scale/kourier
+    steps:
+      - checkout
+
+      # Remove existing go and install 1.13.
+      - run: sudo apt-get remove golang-go && sudo rm -rf /usr/local/go
+      - run: wget https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz
+      - run: sudo tar -C /usr/local -xzf go1.13.1.linux-amd64.tar.gz
+      - run: export PATH=$PATH:/usr/local/go/bin
+
+      - run: curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl
+      - run: chmod +x ./kubectl
+      - run: sudo mv ./kubectl /usr/local/bin/kubectl
+
+      - run: curl -s https://raw.githubusercontent.com/rancher/k3d/master/install.sh | bash
+
+      - run: make test

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ local-setup: ## Builds and deploys kourier locally in a k3s cluster with knative
 	./utils/setup.sh
 
 circleci-setup: ## Builds and deploys kourier locally in a microk8s cluster with knative, forwards the local 8080 to kourier/envoy
-	./utils/setup-circleci.sh
+	sudo ./utils/setup-circleci.sh
 
 test-circleci: test-unit test-integration-circleci ## Runs all the tests for circleCI use.
 
@@ -38,7 +38,7 @@ test-integration: local-setup ## Runs integration tests
 	go test test/* -args -kubeconfig="$(shell k3d get-kubeconfig --name='kourier-integration')"
 
 test-integration-circleci: circleci-setup ## Runs integration tests for circleCI
-	go test test/* -args -kubeconfig="$HOME/.kube/config"
+	go test test/* -args -kubeconfig="$(HOME)/.kube/config"
 
 help: ## Print this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-39s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@ docker-build: ## Builds kourier docker, tagged by default as 3scale-kourier:test
 local-setup: ## Builds and deploys kourier locally in a k3s cluster with knative, forwards the local 8080 to kourier/envoy
 	./utils/setup.sh
 
+circleci-setup: ## Builds and deploys kourier locally in a microk8s cluster with knative, forwards the local 8080 to kourier/envoy
+	./utils/setup-circleci.sh
+
+test-circleci: test-unit test-integration-circleci ## Runs all the tests for circleCI use.
+
 test: test-unit test-integration ## Runs all the tests
 
 test-unit: ## Runs unit tests
@@ -31,6 +36,9 @@ test-unit: ## Runs unit tests
 
 test-integration: local-setup ## Runs integration tests
 	go test test/* -args -kubeconfig="$(shell k3d get-kubeconfig --name='kourier-integration')"
+
+test-integration-circleci: circleci-setup ## Runs integration tests for circleCI
+	go test test/* -args -kubeconfig="$HOME/.kube/config"
 
 help: ## Print this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-39s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/utils/setup-circleci.sh
+++ b/utils/setup-circleci.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+#sudo snap install microk8s --classic
+
+
+if ! command -v microk8s.kubectl >/dev/null; then
+  echo "You need to install microk8s"
+  exit 1
+fi
+
+tag="test_$(git rev-parse --abbrev-ref HEAD)"
+
+sleep 30
+microk8s.kubectl apply -f https://github.com/knative/serving/releases/download/v0.9.0/serving-core.yaml
+
+docker build -t 3scale-kourier:"$tag" ./
+docker image save 3scale-kourier:"$tag" > image.tar
+microk8s.ctr -n k8s.io images import image.tar
+microk8s.kubectl apply -f deploy/kourier-knative.yaml
+microk8s.kubectl patch deployment 3scale-kourier -n knative-serving --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier\",\"image\": \"3scale-kourier:$tag\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
+
+retries=0
+while [[ $(microk8s.kubectl get pods -n knative-serving -l app=3scale-kourier -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+  echo "Waiting for kourier pod to be ready "
+  sleep 10
+  if [ $retries -ge 7 ]; then
+    echo "timedout waiting for kourier pod"
+    exit 1
+  fi
+  retries=$[$retries+1]
+done
+
+microk8s.kubectl port-forward --namespace knative-serving $(microk8s.kubectl get pod -n knative-serving -l "app=3scale-kourier" --output=jsonpath="{.items[0].metadata.name}") 8080:8080 19000:19000 &>/dev/null &


### PR DESCRIPTION
This PR adds a basic integration with CircleCI. There's room for improvement. For example, we could cache the dependencies, docker images, etc, but I think it's good enough for a first version.

This fails because for some reason, I'm not able to create Knative servings in the k3s cluster deployed in Circle. I've seen that creating servings fails both in our code and with `kubectl`. I'll keep investigating.