### PR TITLE
Dockerfile: cache downloaded deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.13
 WORKDIR /app/
+COPY go.mod go.sum ./
+RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o kourier cmd/kourier/main.go
 


### PR DESCRIPTION
This PR changes the Dockerfile so it only downloads the dependencies when there have been changes in `go.mod` or `go.sum`.