### PR TITLE
Use empty structs in watcher channels

### DIFF
--- a/cmd/kourier/main.go
+++ b/cmd/kourier/main.go
@@ -56,7 +56,7 @@ func main() {
 	kubernetesClient := kubernetes.NewKubernetesClient(config)
 	knativeClient := knative.NewKnativeClient(config)
 
-	eventsChan := make(chan string)
+	eventsChan := make(chan struct{})
 
 	stopChan := make(chan struct{})
 	go kubernetesClient.WatchChangesInEndpoints(namespace, eventsChan, stopChan)

--- a/pkg/knative/knative.go
+++ b/pkg/knative/knative.go
@@ -49,7 +49,7 @@ func (kNativeClient *KNativeClient) Ingresses() ([]networkingv1alpha1.Ingress, e
 }
 
 // Pushes an event to the "events" channel received when theres a change in a ClusterIngress is added/deleted/updated.
-func (kNativeClient *KNativeClient) WatchChangesInClusterIngress(namespace string, events chan<- string, stopChan <-chan struct{}) {
+func (kNativeClient *KNativeClient) WatchChangesInClusterIngress(namespace string, events chan<- struct{}, stopChan <-chan struct{}) {
 
 	restClient := kNativeClient.NetworkingClient.RESTClient()
 
@@ -62,16 +62,16 @@ func (kNativeClient *KNativeClient) WatchChangesInClusterIngress(namespace strin
 		time.Second*30, //TODO: Review resync time and adjust.
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				events <- "change"
+				events <- struct{}{}
 			},
 
 			DeleteFunc: func(obj interface{}) {
-				events <- "change"
+				events <- struct{}{}
 			},
 
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				if oldObj != newObj {
-					events <- "change"
+					events <- struct{}{}
 				}
 			},
 		},
@@ -87,7 +87,7 @@ func (kNativeClient *KNativeClient) WatchChangesInClusterIngress(namespace strin
 }
 
 // Pushes an event to the "events" channel received when theres a change in a Ingress is added/deleted/updated.
-func (kNativeClient *KNativeClient) WatchChangesInIngress(namespace string, events chan<- string, stopChan <-chan struct{}) {
+func (kNativeClient *KNativeClient) WatchChangesInIngress(namespace string, events chan<- struct{}, stopChan <-chan struct{}) {
 
 	restClient := kNativeClient.NetworkingClient.RESTClient()
 
@@ -100,16 +100,16 @@ func (kNativeClient *KNativeClient) WatchChangesInIngress(namespace string, even
 		time.Second*30, //TODO: Review resync time and adjust.
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				events <- "change"
+				events <- struct{}{}
 			},
 
 			DeleteFunc: func(obj interface{}) {
-				events <- "change"
+				events <- struct{}{}
 			},
 
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				if oldObj != newObj {
-					events <- "change"
+					events <- struct{}{}
 				}
 			},
 		},

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -52,7 +52,7 @@ func (kubernetesClient *KubernetesClient) GetSecret(namespace string, secretName
 }
 
 // Pushes an event to the "events" channel received when an endpoint is added/deleted/updated.
-func (kubernetesClient *KubernetesClient) WatchChangesInEndpoints(namespace string, events chan<- string, stopChan <-chan struct{}) {
+func (kubernetesClient *KubernetesClient) WatchChangesInEndpoints(namespace string, events chan<- struct{}, stopChan <-chan struct{}) {
 	restClient := kubernetesClient.Client.CoreV1().RESTClient()
 
 	watchlist := cache.NewListWatchFromClient(restClient, "endpoints", namespace,
@@ -64,16 +64,16 @@ func (kubernetesClient *KubernetesClient) WatchChangesInEndpoints(namespace stri
 		time.Second*30,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				events <- "change"
+				events <- struct{}{}
 			},
 
 			DeleteFunc: func(obj interface{}) {
-				events <- "change"
+				events <- struct{}{}
 			},
 
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				if oldObj != newObj {
-					events <- "change"
+					events <- struct{}{}
 				}
 			},
 		},


### PR DESCRIPTION
Minor change. By using empty structs we signal that we do not care about the values.