### PR TITLE
Adds websocket upgrade support

### DIFF
--- a/pkg/envoy/caches.go
+++ b/pkg/envoy/caches.go
@@ -202,7 +202,13 @@ func createRouteForRevision(routeName string, i int, httpPath *v1alpha1.HTTPIngr
 					Clusters: wrs,
 				},
 			},
-			Timeout:     &routeTimeout,
+			Timeout: &routeTimeout,
+			UpgradeConfigs: []*route.RouteAction_UpgradeConfig{{
+				UpgradeType: "websocket",
+				Enabled: &types.BoolValue{
+					Value: true,
+				},
+			},},
 			RetryPolicy: createRetryPolicyForRoute(httpPath),
 		}},
 		RequestHeadersToAdd: headersToAdd(httpPath.AppendHeaders),


### PR DESCRIPTION
https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/websocket.html?highlight=upgrades#websocket-and-http-upgrades

With this we can pass the e2e tests from knative serving: 

```
--- PASS: TestWebSocket (5.11s)
--- PASS: TestWebSocketViaActivator (8.11s)
```