### PR TITLE
Internal routes e2e 

### DIFF
--- a/cmd/kourier/main.go
+++ b/cmd/kourier/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/workqueue"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"kourier/pkg/envoy"
@@ -52,7 +53,8 @@ func init() {
 }
 
 func main() {
-	namespace := ""
+	namespace := v1.NamespaceAll
+
 	config := kubernetes.Config(*kubeconfig)
 	kubernetesClient := kubernetes.NewKubernetesClient(config)
 	knativeClient := knative.NewKnativeClient(config)

--- a/deploy/knative_e2e_tests/kourier-istio-system.yaml
+++ b/deploy/knative_e2e_tests/kourier-istio-system.yaml
@@ -1,8 +1,32 @@
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+spec:
+status:
+  phase: Active
+---
+apiVersion: v1
 kind: Service
 metadata:
-  name: kourier
-  namespace: knative-serving
+  name: istio-ingressgateway
+  namespace: istio-system
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: 3scale-kourier
+  type: LoadBalancer
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier-external
+  namespace: istio-system
 spec:
   ports:
     - port: 80
@@ -14,11 +38,27 @@ spec:
 status:
   loadBalancer: {}
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier-internal
+  namespace: istio-system
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8081
+  selector:
+    app: 3scale-kourier
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: 3scale-kourier
-  namespace: knative-serving
+  namespace: istio-system
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
@@ -82,7 +122,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: 3scale-kourier
-  namespace: knative-serving
+  namespace: istio-system
 rules:
   - apiGroups: [""]
     resources: [ "endpoints", "namespaces", "services", "secrets"]
@@ -101,7 +141,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: 3scale-kourier
-  namespace: knative-serving
+  namespace: istio-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -114,48 +154,16 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: 3scale-kourier
-    namespace: knative-serving
+    namespace: istio-system
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: kourier
-  namespace: knative-serving
+  namespace: istio-system
 spec:
   ports:
-    - port: 80
-      protocol: TCP
-      targetPort: 8080
-  selector:
-    app: 3scale-kourier
-  type: ClusterIP
-status:
-  loadBalancer: {}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kourier-internal
-  namespace: knative-serving
-spec:
-  ports:
-    - port: 80
-      protocol: TCP
-      targetPort: 8081
-  selector:
-    app: 3scale-kourier
-  type: ClusterIP
-status:
-  loadBalancer: {}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kourier-external
-  namespace: knative-serving
-spec:
-  ports:
-    - port: 80
+    - port: 8080
       protocol: TCP
       targetPort: 8080
   selector:
@@ -168,7 +176,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kourier-bootstrap
-  namespace: knative-serving
+  namespace: istio-system
 data:
   envoy-bootstrap.yaml: |
     admin:

--- a/pkg/envoy/caches.go
+++ b/pkg/envoy/caches.go
@@ -15,6 +15,7 @@ import (
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -55,6 +56,19 @@ func CachesForClusterIngresses(Ingresses []v1alpha1.IngressAccessor, kubeClient 
 			// This is the fix...
 			// More info https://github.com/envoyproxy/envoy/issues/886
 			for _, host := range rule.Hosts {
+				// TODO: Improve hosts generation code
+				// Generates :
+				// 		* subroute_host.namespace
+				//		* subroute_host.namespace.svc
+				if strings.Contains(host, ".svc.cluster.local") {
+					splits := strings.Split(host, ".")
+					domain := splits[0] + "." + splits[1]
+					domains = append(domains, domain)
+					domains = append(domains, domain+":*")
+					domain = splits[0] + "." + splits[1] + ".svc"
+					domains = append(domains, domain)
+					domains = append(domains, domain+":*")
+				}
 				domains = append(domains, host)
 				domains = append(domains, host+":*")
 			}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -54,7 +54,7 @@ func (kubernetesClient *KubernetesClient) GetSecret(namespace string, secretName
 // Pushes an event to the "events" queue received when an endpoint is added/deleted/updated.
 func (kubernetesClient *KubernetesClient) WatchChangesInEndpoints(namespace string, eventsQueue *workqueue.Type, stopChan <-chan struct{}) {
 	restClient := kubernetesClient.Client.CoreV1().RESTClient()
-
+	
 	watchlist := cache.NewListWatchFromClient(restClient, "endpoints", namespace,
 		fields.Everything())
 
@@ -80,4 +80,5 @@ func (kubernetesClient *KubernetesClient) WatchChangesInEndpoints(namespace stri
 	)
 
 	controller.Run(stopChan)
+
 }


### PR DESCRIPTION
Improvements to route visibility:

- Define external/internal services for kourier
- Adds new domains based on "routeName+namespace"
- Adds deploy scripts for passing the e2e tests of knative serving.