### PR TITLE
Split Kourier POD into control plane and data plane

### DIFF
--- a/cmd/kourier/main.go
+++ b/cmd/kourier/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	nodeID         = "3scale-kourier"
+	nodeID         = "3scale-kourier-gateway"
 	gatewayPort    = 19001
 	managementPort = 18000
 )

--- a/conf/envoy-bootstrap.yaml
+++ b/conf/envoy-bootstrap.yaml
@@ -17,14 +17,14 @@ dynamic_resources:
   lds_config:
     ads: {}
 node:
-  cluster: test-cluster
-  id: 3scale-kourier
+  cluster: kourier-knative
+  id: 3scale-kourier-gateway
 static_resources:
   clusters:
     - connect_timeout: 1s
       hosts:
         - socket_address:
-            address: "kourier"
+            address: "kourier-control"
             port_value: 18000
       http2_protocol_options: {}
       name: xds_cluster

--- a/deploy/knative_e2e_tests/kourier-istio-system.yaml
+++ b/deploy/knative_e2e_tests/kourier-istio-system.yaml
@@ -21,11 +21,10 @@ spec:
   type: LoadBalancer
 status:
   loadBalancer: {}
----
 apiVersion: v1
 kind: Service
 metadata:
-  name: kourier-external
+  name: kourier
   namespace: istio-system
 spec:
   ports:
@@ -38,26 +37,10 @@ spec:
 status:
   loadBalancer: {}
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: kourier-internal
-  namespace: istio-system
-spec:
-  ports:
-    - port: 80
-      protocol: TCP
-      targetPort: 8081
-  selector:
-    app: 3scale-kourier
-  type: ClusterIP
-status:
-  loadBalancer: {}
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: 3scale-kourier
+  name: 3scale-kourier-gateway
   namespace: istio-system
 spec:
   progressDeadlineSeconds: 600
@@ -65,7 +48,7 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: 3scale-kourier
+      app: 3scale-kourier-gateway
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -74,7 +57,7 @@ spec:
   template:
     metadata:
       labels:
-        app: 3scale-kourier
+        app: 3scale-kourier-gateway
     spec:
       containers:
         - args:
@@ -82,7 +65,7 @@ spec:
             - /tmp/config/envoy-bootstrap.yaml
           image: envoyproxy/envoy-alpine:latest
           imagePullPolicy: Always
-          name: envoy
+          name: kourier-gateway
           ports:
             - containerPort: 8080
               protocol: TCP
@@ -92,9 +75,42 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /tmp/config
+      volumes:
+        - name: config-volume
+          configMap:
+            name: kourier-bootstrap
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: 3scale-kourier-control
+  namespace: istio-system
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: 3scale-kourier-control
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: 3scale-kourier-control
+    spec:
+      containers:
         - image: quay.io/3scale/kourier:v0.1.0
           imagePullPolicy: Always
-          name: kourier
+          name: kourier-control
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
@@ -107,10 +123,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-      volumes:
-        - name: config-volume
-          configMap:
-            name: kourier-bootstrap
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -132,7 +144,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["networking.internal.knative.dev"]
     resources: ["ingresses/status","clusteringresses/status"]
-    verbs: ["update"] 
+    verbs: ["update"]
   - apiGroups: [ "apiextensions.k8s.io" ]
     resources: [ "customresourcedefinitions" ]
     verbs: ["get", "list", "watch"]
@@ -163,11 +175,59 @@ metadata:
   namespace: istio-system
 spec:
   ports:
-    - port: 8080
+    - port: 80
       protocol: TCP
       targetPort: 8080
   selector:
-    app: 3scale-kourier
+    app: 3scale-kourier-gateway
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier-internal
+  namespace: istio-system
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8081
+  selector:
+    app: 3scale-kourier-gateway
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier-external
+  namespace: istio-system
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: 3scale-kourier-gateway
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier-control
+  namespace: istio-system
+spec:
+  ports:
+    - port: 18000
+      protocol: TCP
+      targetPort: 18000
+  selector:
+    app: 3scale-kourier-control
   type: ClusterIP
 status:
   loadBalancer: {}
@@ -196,14 +256,14 @@ data:
       lds_config:
         ads: {}
     node:
-      cluster: test-cluster
-      id: 3scale-kourier
+      cluster: kourier-knative
+      id: 3scale-kourier-gateway
     static_resources:
       clusters:
         - connect_timeout: 1s
           hosts:
             - socket_address:
-                address: "127.0.0.1"
+                address: "kourier-control"
                 port_value: 18000
           http2_protocol_options: {}
           name: xds_cluster

--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -17,7 +17,7 @@ status:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: 3scale-kourier
+  name: 3scale-kourier-gateway
   namespace: knative-serving
 spec:
   progressDeadlineSeconds: 600
@@ -25,7 +25,7 @@ spec:
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: 3scale-kourier
+      app: 3scale-kourier-gateway
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -34,7 +34,7 @@ spec:
   template:
     metadata:
       labels:
-        app: 3scale-kourier
+        app: 3scale-kourier-gateway
     spec:
       containers:
         - args:
@@ -42,7 +42,7 @@ spec:
             - /tmp/config/envoy-bootstrap.yaml
           image: envoyproxy/envoy-alpine:latest
           imagePullPolicy: Always
-          name: envoy
+          name: kourier-gateway
           ports:
             - containerPort: 8080
               protocol: TCP
@@ -52,9 +52,42 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /tmp/config
+      volumes:
+        - name: config-volume
+          configMap:
+            name: kourier-bootstrap
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: 3scale-kourier-control
+  namespace: knative-serving
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: 3scale-kourier-control
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: 3scale-kourier-control
+    spec:
+      containers:
         - image: quay.io/3scale/kourier:v0.1.0
           imagePullPolicy: Always
-          name: kourier
+          name: kourier-control
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
@@ -67,10 +100,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-      volumes:
-        - name: config-volume
-          configMap:
-            name: kourier-bootstrap
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -127,7 +156,7 @@ spec:
       protocol: TCP
       targetPort: 8080
   selector:
-    app: 3scale-kourier
+    app: 3scale-kourier-gateway
   type: ClusterIP
 status:
   loadBalancer: {}
@@ -143,7 +172,7 @@ spec:
       protocol: TCP
       targetPort: 8081
   selector:
-    app: 3scale-kourier
+    app: 3scale-kourier-gateway
   type: ClusterIP
 status:
   loadBalancer: {}
@@ -159,7 +188,23 @@ spec:
       protocol: TCP
       targetPort: 8080
   selector:
-    app: 3scale-kourier
+    app: 3scale-kourier-gateway
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier-control
+  namespace: knative-serving
+spec:
+  ports:
+    - port: 18000
+      protocol: TCP
+      targetPort: 18000
+  selector:
+    app: 3scale-kourier-control
   type: ClusterIP
 status:
   loadBalancer: {}
@@ -188,14 +233,14 @@ data:
       lds_config:
         ads: {}
     node:
-      cluster: test-cluster
-      id: 3scale-kourier
+      cluster: kourier-knative
+      id: 3scale-kourier-gateway
     static_resources:
       clusters:
         - connect_timeout: 1s
           hosts:
             - socket_address:
-                address: "127.0.0.1"
+                address: "kourier-control"
                 port_value: 18000
           http2_protocol_options: {}
           name: xds_cluster

--- a/utils/setup-circleci.sh
+++ b/utils/setup-circleci.sh
@@ -16,21 +16,32 @@ chown -R circleci "$HOME"/.kube
 docker build -t 3scale-kourier:"$tag" ./
 docker image save 3scale-kourier:"$tag" > image.tar
 microk8s.ctr -n k8s.io images import image.tar
+microk8s.enable dns
 microk8s.kubectl apply -f deploy/kourier-knative.yaml
-microk8s.kubectl patch deployment 3scale-kourier -n knative-serving --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier\",\"image\": \"3scale-kourier:$tag\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
+microk8s.kubectl patch deployment 3scale-kourier-control -n knative-serving --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier-control\",\"image\": \"3scale-kourier:$tag\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
 microk8s.kubectl patch configmap/config-domain -n knative-serving --type merge -p '{"data":{"127.0.0.1.nip.io":""}}'
 microk8s.kubectl patch configmap/config-network -n knative-serving --type merge -p '{"data":{"clusteringress.class":"kourier.ingress.networking.knative.dev","ingress.class":"kourier.ingress.networking.knative.dev"}}'
 
 retries=0
-while [[ $(microk8s.kubectl get pods -n knative-serving -l app=3scale-kourier -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
-  echo "Waiting for kourier pod to be ready "
+while [[ $(microk8s.kubectl get pods -n knative-serving -l app=3scale-kourier-control -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+  echo "Waiting for kourier control pod to be ready "
   sleep 10
   if [ $retries -ge 7 ]; then
-    echo "timedout waiting for kourier pod"
+    echo "timed out waiting for kourier control pod"
     exit 1
   fi
   retries=$[$retries+1]
 done
 
+retries=0
+while [[ $(microk8s.kubectl get pods -n knative-serving -l app=3scale-kourier-gateway -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+  echo "Waiting for kourier gateway pod to be ready "
+  sleep 10
+  if [ $retries -ge 7 ]; then
+    echo "timed out waiting for kourier gateway pod"
+    exit 1
+  fi
+  retries=$[$retries+1]
+done
 
-microk8s.kubectl port-forward --namespace knative-serving $(microk8s.kubectl get pod -n knative-serving -l "app=3scale-kourier" --output=jsonpath="{.items[0].metadata.name}") 8080:8080 19000:19000 &>/dev/null &
+microk8s.kubectl port-forward --namespace knative-serving $(microk8s.kubectl get pod -n knative-serving -l "app=3scale-kourier-gateway" --output=jsonpath="{.items[0].metadata.name}") 8080:8080 19000:19000 &>/dev/null &

--- a/utils/setup.sh
+++ b/utils/setup.sh
@@ -21,19 +21,30 @@ k3d import-images 3scale-kourier:"$tag" --name='kourier-integration'
 kubectl apply -f https://github.com/knative/serving/releases/download/v0.9.0/serving.yaml || true
 kubectl scale deployment traefik --replicas=0 -n kube-system
 kubectl apply -f deploy/kourier-knative.yaml
-kubectl patch deployment 3scale-kourier -n knative-serving --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier\",\"image\": \"3scale-kourier:$tag\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
+kubectl patch deployment 3scale-kourier-control -n knative-serving --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier-control\",\"image\": \"3scale-kourier:$tag\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
 kubectl patch configmap/config-domain -n knative-serving --type merge -p '{"data":{"127.0.0.1.nip.io":""}}'
 kubectl patch configmap/config-network -n knative-serving --type merge -p '{"data":{"clusteringress.class":"kourier.ingress.networking.knative.dev","ingress.class":"kourier.ingress.networking.knative.dev"}}'
 
 retries=0
-while [[ $(kubectl get pods -n knative-serving -l app=3scale-kourier -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
-  echo "Waiting for kourier pod to be ready "
+while [[ $(kubectl get pods -n knative-serving -l app=3scale-kourier-control -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+  echo "Waiting for kourier control pod to be ready "
   sleep 10
   if [ $retries -ge 7 ]; then
-    echo "timedout waiting for kourier pod"
+    echo "timedout waiting for kourier control pod"
     exit 1
   fi
   retries=$[$retries+1]
 done
 
-kubectl port-forward --namespace knative-serving $(kubectl get pod -n knative-serving -l "app=3scale-kourier" --output=jsonpath="{.items[0].metadata.name}") 8080:8080 8081:8081 19000:19000 8443:8443 &>/dev/null &
+retries=0
+while [[ $(kubectl get pods -n knative-serving -l app=3scale-kourier-gateway -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+  echo "Waiting for kourier gateway pod to be ready "
+  sleep 10
+  if [ $retries -ge 7 ]; then
+    echo "timedout waiting for kourier gateway pod"
+    exit 1
+  fi
+  retries=$[$retries+1]
+done
+
+kubectl port-forward --namespace knative-serving $(kubectl get pod -n knative-serving -l "app=3scale-kourier-gateway" --output=jsonpath="{.items[0].metadata.name}") 8080:8080 8081:8081 19000:19000 8443:8443 &>/dev/null &


### PR DESCRIPTION
Splits 3scale kourier POD into two new PODS:

* 3scale-kourier-gateway: Contains the Envoy container

* 3scale-kourier-control: Contains the Kourier control plane container.