### PR TITLE
Adapt instructions to the new pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ kubectl apply -f https://github.com/knative/serving/releases/download/v0.9.0/ser
 
 - Then install Kourier:
 ```bash
-kubectl -f apply deploy/kourier-knative.yaml
+kubectl apply -f deploy/kourier-knative.yaml
 ```
 
 - Configure Knative Serving to use the proper "ingress.class":
@@ -43,7 +43,7 @@ kubectl patch configmap/config-network \
  kubectl patch configmap/config-domain \
   -n knative-serving \
   --type merge \
-  -p '{"data":{"127.0.0.1.nip.io":"\"\""}}'
+  -p '{"data":{"127.0.0.1.nip.io":""}}'
 ```
 
 - (OPTIONAL) Deploy a sample hello world app:
@@ -54,11 +54,9 @@ kubectl apply -f ./samples/helloworld-go.yaml
 - (OPTIONAL) For testing purposes, you can use port-forwarding to make requests to Kourier
 from your machine:
 ```bash
-kubectl port-forward --namespace knative-serving
-$(kubectl get pod -n knative-serving -l "app=3scale-kourier"
---output=jsonpath="{.items[0].metadata.name}") 8080:8080 19000:19000 8443:8443`
+kubectl port-forward --namespace knative-serving $(kubectl get pod -n knative-serving -l "app=3scale-kourier-gateway" --output=jsonpath="{.items[0].metadata.name}") 8080:8080 19000:19000 8443:8443
 
-curl -v -H "Host: 127.0.0.1.nip.io" http://localhost:8080 
+curl -v -H "Host: helloworld-go.default.127.0.0.1.nip.io" http://localhost:8080 
 ```
 
 ## Features

--- a/docs/knative_e2e_tests.md
+++ b/docs/knative_e2e_tests.md
@@ -26,25 +26,20 @@ docker build -t 3scale-kourier:my_tests ./
 
 k3d import-images 3scale-kourier:my_tests --name='kourier-integration'
 
-kubectl patch deployment 3scale-kourier -n istio-system --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier\",\"image\": \"3scale-kourier:my_tests\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
+kubectl patch deployment 3scale-kourier-control -n istio-system --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier-control\",\"image\": \"3scale-kourier:my_tests\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
 ```
 
 - Clean-up some things that are not needed:
 ```bash
-kubectl delete deployment 3scale-kourier -n knative-serving
-kubectl delete service kourier -n knative-serving
+kubectl delete deployment 3scale-kourier-control 3scale-kourier-gateway -n knative-serving
+kubectl delete service kourier kourier-control kourier-external kourier-internal -n knative-serving
 kubectl delete service traefik -n kube-system
-```
-
-- Edit the config domain adding `127.0.0.1.nip.io: ""` just below `data:`
-```bash
-kubectl edit configmap config-domain -n knative-serving
 ```
 
 - Port-forward Kourier. Make sure you do not have anything else on these ports,
 otherwise, it will fail:
 ```bash
-sudo kubectl port-forward --namespace istio-system $(kubectl get pod -n istio-system -l "app=3scale-kourier" --output=jsonpath="{.items[0].metadata.name}") 80:8080 8081:8081 19000:19000 8443:8443
+sudo kubectl port-forward --namespace istio-system $(kubectl get pod -n istio-system -l "app=3scale-kourier-gateway" --output=jsonpath="{.items[0].metadata.name}") 80:8080 8081:8081 19000:19000 8443:8443
 ```
 
 ## Run the Knative tests


### PR DESCRIPTION
This PR adapts the instructions in the README and in `docs/knative_e2e_tests` to take into account the new pods introduced in #68 