### PR TITLE
Fix missing istio-ingressgateway Service in istio yaml

### DIFF
--- a/deploy/knative_e2e_tests/kourier-istio-system.yaml
+++ b/deploy/knative_e2e_tests/kourier-istio-system.yaml
@@ -21,6 +21,7 @@ spec:
   type: LoadBalancer
 status:
   loadBalancer: {}
+---
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
A missing `---` was causing the istio-ingressgateway Service to not get created when applying this yaml via `oc apply`.