### PR TITLE
Add a port name of 'http2' to kourier Services

### DIFF
--- a/deploy/knative_e2e_tests/kourier-istio-system.yaml
+++ b/deploy/knative_e2e_tests/kourier-istio-system.yaml
@@ -13,7 +13,8 @@ metadata:
   namespace: istio-system
 spec:
   ports:
-    - port: 80
+    - name: http2
+      port: 80
       protocol: TCP
       targetPort: 8080
   selector:
@@ -160,7 +161,8 @@ metadata:
   namespace: istio-system
 spec:
   ports:
-    - port: 80
+    - name: http2
+      port: 80
       protocol: TCP
       targetPort: 8080
   selector:
@@ -176,7 +178,8 @@ metadata:
   namespace: istio-system
 spec:
   ports:
-    - port: 80
+    - name: http2
+      port: 80
       protocol: TCP
       targetPort: 8081
   selector:
@@ -192,7 +195,8 @@ metadata:
   namespace: istio-system
 spec:
   ports:
-    - port: 80
+    - name: http2
+      port: 80
       protocol: TCP
       targetPort: 8080
   selector:

--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -152,7 +152,8 @@ metadata:
   namespace: knative-serving
 spec:
   ports:
-    - port: 80
+    - name: http2
+      port: 80
       protocol: TCP
       targetPort: 8080
   selector:
@@ -168,7 +169,8 @@ metadata:
   namespace: knative-serving
 spec:
   ports:
-    - port: 80
+    - name: http2
+      port: 80
       protocol: TCP
       targetPort: 8081
   selector:
@@ -184,7 +186,8 @@ metadata:
   namespace: knative-serving
 spec:
   ports:
-    - port: 80
+    - name: http2
+      port: 80
       protocol: TCP
       targetPort: 8080
   selector:


### PR DESCRIPTION
When fronted by OpenShift Routes and the OpenShift Serverless
operator, a port name of 'http2' is expected so that the OpenShift
Route sends traffic to the appropriate port.

This should fix a large number of the failing tests when used with the
OpenShift Serverless operator.