### PR TITLE
Refactor: extract HttpConnectionManager

### DIFF
--- a/pkg/envoy/http_connection_manager.go
+++ b/pkg/envoy/http_connection_manager.go
@@ -1,0 +1,49 @@
+package envoy
+
+import (
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	accesslogv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
+	httpconnectionmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	pstruct "github.com/golang/protobuf/ptypes/struct"
+)
+
+func newHttpConnectionManager(virtualHosts []*route.VirtualHost) httpconnectionmanagerv2.HttpConnectionManager {
+	return httpconnectionmanagerv2.HttpConnectionManager{
+		CodecType:  httpconnectionmanagerv2.HttpConnectionManager_AUTO,
+		StatPrefix: "ingress_http",
+		RouteSpecifier: &httpconnectionmanagerv2.HttpConnectionManager_RouteConfig{
+			RouteConfig: &v2.RouteConfiguration{
+				Name:         "local_route",
+				VirtualHosts: virtualHosts,
+			},
+		},
+		HttpFilters: []*httpconnectionmanagerv2.HttpFilter{
+			{
+				Name: wellknown.Router,
+			},
+		},
+
+		AccessLog: accessLogs(),
+	}
+}
+
+// Outputs to /dev/stdout using the default format
+func accessLogs() []*accesslogv2.AccessLog {
+	accessLogConfigFields := make(map[string]*pstruct.Value)
+	accessLogConfigFields["path"] = &pstruct.Value{
+		Kind: &pstruct.Value_StringValue{
+			StringValue: "/dev/stdout",
+		},
+	}
+
+	return []*accesslogv2.AccessLog{
+		{
+			Name: "envoy.file_access_log",
+			ConfigType: &accesslogv2.AccessLog_Config{
+				Config: &pstruct.Struct{Fields: accessLogConfigFields},
+			},
+		},
+	}
+}

--- a/pkg/envoy/http_connection_manager_test.go
+++ b/pkg/envoy/http_connection_manager_test.go
@@ -1,0 +1,42 @@
+package envoy
+
+import (
+	"testing"
+
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	v2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
+	httpconnectionmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	pstruct "github.com/golang/protobuf/ptypes/struct"
+	"gotest.tools/assert"
+)
+
+var testVirtualHosts = []*route.VirtualHost{
+	{
+		Name:    "helloworld-go",
+		Domains: []string{"helloworld-go.default.127.0.0.1.nip.io"},
+		Routes: []*route.Route{
+			{
+				Name: "helloworld-route",
+			},
+		},
+	},
+}
+
+func TestCreatesManagerWithVirtualHosts(t *testing.T) {
+	connManager := newHttpConnectionManager(testVirtualHosts)
+
+	VirtualHosts := connManager.RouteSpecifier.(*httpconnectionmanagerv2.HttpConnectionManager_RouteConfig).
+		RouteConfig.VirtualHosts
+
+	assert.DeepEqual(t, VirtualHosts, testVirtualHosts)
+}
+
+func TestCreatesManagerThatOutputsToStdOut(t *testing.T) {
+	connManager := newHttpConnectionManager(testVirtualHosts)
+
+	accessLog := connManager.AccessLog[0]
+	accessLogPath := accessLog.ConfigType.(*v2.AccessLog_Config).
+		Config.Fields["path"].Kind.(*pstruct.Value_StringValue).StringValue
+
+	assert.Equal(t, "/dev/stdout", accessLogPath)
+}

--- a/pkg/envoy/listener_test.go
+++ b/pkg/envoy/listener_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCreateHTTPListener(t *testing.T) {
-	manager := httpConnectionManager([]*route.VirtualHost{})
+	manager := newHttpConnectionManager([]*route.VirtualHost{})
 	KubeClient := newMockedKubeClientListener("", "")
 
 	l, err := newExternalEnvoyListener(false, &manager, KubeClient)
@@ -36,7 +36,7 @@ func TestCreateHTTPSListener(t *testing.T) {
 	key := "some_key"
 	KubeClient := newMockedKubeClientListener(cert, key)
 
-	manager := httpConnectionManager([]*route.VirtualHost{})
+	manager := newHttpConnectionManager([]*route.VirtualHost{})
 
 	l, err := newExternalEnvoyListener(true, &manager, KubeClient)
 	if err != nil {


### PR DESCRIPTION
Extracts the instantiation of `HttpConnectionManager` to its own file to make the code more readable and also to be able to test it in isolation.