### PR TITLE
CHANGELOG: add links for versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.1.0] - 2019-10-23
 
 First release.
+
+[0.2.1]: https://github.com/3scale/kourier/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/3scale/kourier/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/3scale/kourier/releases/tag/v0.1.0


### PR DESCRIPTION
Same format as in https://keepachangelog.com/en/1.0.0/