### PR TITLE
Extract and test ClusterCache

### DIFF
--- a/pkg/envoy/cluster_cache.go
+++ b/pkg/envoy/cluster_cache.go
@@ -1,0 +1,62 @@
+// This is a cache of Envoy clusters
+//
+// To figure out the Envoy clusters that we need to set in the Envoy config, we
+// check the Ingress. However, there's a case where there are old clusters being
+// used that cannot be extracted from the Ingress.
+//
+// Imagine a scenario where a revision of a Knative Serving is deployed. Later,
+// another revision is deployed. Even if the new revision is configured to get
+// 100% of the traffic, Envoy will keep the existing connections to the old
+// revision for some time. Envoy marks the listeners attending those connections
+// as draining. The routing info associated with the old revision no longer
+// appears in the Ingress. However, we need to set the old clusters in order to
+// be able to attend those connections in "draining" state. Otherwise, requests
+// coming from those connections fail with a 5xx "No route" error.
+
+package envoy
+
+import (
+	"strings"
+	"time"
+
+	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache"
+	gocache "github.com/patrickmn/go-cache"
+)
+
+const (
+	defaultExpiration      = 5 * time.Minute
+	defaultCleanupInterval = 10 * time.Minute
+)
+
+type ClustersCache struct {
+	clusters *gocache.Cache
+}
+
+func newClustersCache() ClustersCache {
+	goCache := gocache.New(defaultExpiration, defaultCleanupInterval)
+	return ClustersCache{clusters: goCache}
+}
+
+func newClustersCacheWithExpAndCleanupIntervals(expiration time.Duration, cleanupInterval time.Duration) ClustersCache {
+	goCache := gocache.New(expiration, cleanupInterval)
+	return ClustersCache{clusters: goCache}
+}
+
+func (cc *ClustersCache) set(serviceWithRevisionName string, path string, namespace string, cluster envoycache.Resource) {
+	key := key(serviceWithRevisionName, path, namespace)
+	cc.clusters.Set(key, cluster, gocache.DefaultExpiration)
+}
+
+func (cc *ClustersCache) list() []envoycache.Resource {
+	var res []envoycache.Resource
+
+	for _, cluster := range cc.clusters.Items() {
+		res = append(res, cluster.Object.(envoycache.Resource))
+	}
+
+	return res
+}
+
+func key(serviceWithRevisionName string, path string, namespace string) string {
+	return strings.Join([]string{namespace, serviceWithRevisionName, path}, ":")
+}

--- a/pkg/envoy/cluster_cache_test.go
+++ b/pkg/envoy/cluster_cache_test.go
@@ -1,0 +1,78 @@
+package envoy
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"gotest.tools/assert"
+)
+
+var testCluster1 = envoy_api_v2.Cluster{
+	Name: "test_cluster_1",
+}
+
+var testCluster2 = envoy_api_v2.Cluster{
+	Name: "test_cluster_2",
+}
+
+func TestSetCluster(t *testing.T) {
+	cache := newClustersCache()
+	cache.set("helloworld", "/", "test_namespace", &testCluster1)
+
+	list := cache.list()
+
+	assert.Equal(t, 1, len(list))
+	assert.Equal(t, testCluster1.Name, list[0].(*envoy_api_v2.Cluster).Name)
+}
+
+func TestSetSeveralClusters(t *testing.T) {
+	cache := newClustersCache()
+	cache.set("helloworld_1", "/", "test_namespace", &testCluster1)
+	cache.set("helloworld_2", "/", "test_namespace", &testCluster2)
+
+	list := cache.list()
+	var names []string
+	for _, cluster := range list {
+		names = append(names, cluster.(*envoy_api_v2.Cluster).Name)
+	}
+
+	assert.Equal(t, 2, len(list))
+
+	// Could be returned in any order
+	expectedNames := []string{testCluster1.Name, testCluster2.Name}
+	sort.Strings(expectedNames)
+	sort.Strings(names)
+	assert.DeepEqual(t, expectedNames, names)
+}
+
+func TestSetExistingClusterReplacesIt(t *testing.T) {
+	cache := newClustersCache()
+	cache.set("helloworld", "/", "test_namespace", &testCluster1)
+	cache.set("helloworld", "/", "test_namespace", &testCluster2) // should replace
+
+	list := cache.list()
+
+	assert.Equal(t, 1, len(list))
+	assert.Equal(t, testCluster2.Name, list[0].(*envoy_api_v2.Cluster).Name)
+}
+
+func TestClustersExpire(t *testing.T) {
+	cleanupInterval := time.Second
+	cache := newClustersCacheWithExpAndCleanupIntervals(time.Second, cleanupInterval)
+	cache.set("helloworld", "/", "test_namespace", &testCluster1)
+	time.Sleep(cleanupInterval + time.Second)
+
+	list := cache.list()
+
+	assert.Equal(t, 0, len(list))
+}
+
+func TestListWhenThereAreNoClusters(t *testing.T) {
+	cache := newClustersCache()
+
+	list := cache.list()
+
+	assert.Equal(t, 0, len(list))
+}


### PR DESCRIPTION
This PR extracts the cluster cache introduced in #91 . The PR also adds tests for the cache and also an explanation of why it is needed. @jmprusi please let me know if you find that explanation clear enough.