### PR TITLE
Change incorrect error message

### DIFF
--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -139,7 +139,7 @@ func (envoyXdsServer *EnvoyXdsServer) SetSnapshotForIngresses(nodeId string, Ing
 		for _, ingress := range Ingresses {
 			err := envoyXdsServer.knativeClient.MarkIngressReady(ingress)
 			if err != nil {
-				log.Error(err)
+				log.Debug("Tried to mark an ingress as ready, but it no longer exists: ", err)
 			}
 		}
 	}


### PR DESCRIPTION
We were logging an error when trying to update an ingress that no longer exists. This is not really an error, it could happen if the ingress was deleted while running the loop to update the config.

I noticed this error while running the "TestRouteVisibilityChanges" test of the Knative e2e suite.