### PR TITLE
Adds readiness probes to the gateway container

### DIFF
--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -1,3 +1,4 @@
 FROM envoyproxy/envoy-alpine:latest
+RUN apk --no-cache add curl
 USER 1001
 CMD ["envoy" "-c" "/etc/envoy/envoy.yaml"]

--- a/deploy/knative_e2e_tests/kourier-istio-system.yaml
+++ b/deploy/knative_e2e_tests/kourier-istio-system.yaml
@@ -49,7 +49,7 @@ spec:
         - args:
             - -c
             - /tmp/config/envoy-bootstrap.yaml
-          image: quay.io/3scale/kourier-gateway:v0.1.0
+          image: quay.io/3scale/kourier-gateway:v0.1.1
           imagePullPolicy: Always
           name: kourier-gateway
           ports:
@@ -61,6 +61,11 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /tmp/config
+          readinessProbe:
+            exec:
+              command: ['ash','-c','curl -H "Host: internalkourier" http://localhost:8081/__internalkouriersnapshot']
+            initialDelaySeconds: 5
+            periodSeconds: 2
       volumes:
         - name: config-volume
           configMap:

--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -14,6 +14,18 @@ spec:
 status:
   loadBalancer: {}
 ---
+
+
+
+
+
+
+
+
+
+
+
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -40,7 +52,7 @@ spec:
         - args:
             - -c
             - /tmp/config/envoy-bootstrap.yaml
-          image: quay.io/3scale/kourier-gateway:v0.1.0
+          image: quay.io/3scale/kourier-gateway:v0.1.1
           imagePullPolicy: Always
           name: kourier-gateway
           ports:
@@ -52,6 +64,11 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /tmp/config
+          readinessProbe:
+            exec:
+              command: ['ash','-c','curl -H "Host: internalkourier" http://localhost:8081/__internalkouriersnapshot']
+            initialDelaySeconds: 5
+            periodSeconds: 2
       volumes:
         - name: config-volume
           configMap:
@@ -61,6 +78,30 @@ spec:
       schedulerName: default-scheduler
       securityContext: {}
       terminationGracePeriodSeconds: 30
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -14,18 +14,6 @@ spec:
 status:
   loadBalancer: {}
 ---
-
-
-
-
-
-
-
-
-
-
-
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -78,30 +66,6 @@ spec:
       schedulerName: default-scheduler
       securityContext: {}
       terminationGracePeriodSeconds: 30
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
We check that the gateway has been initialized with a kourier config before marking it ready.