### PR TITLE
Only route the public endpoints object of a revision.

### DIFF
--- a/pkg/envoy/caches_test.go
+++ b/pkg/envoy/caches_test.go
@@ -128,12 +128,10 @@ func TestTrafficSplits(t *testing.T) {
 
 type mockedKubeClient struct{}
 
-func (kubeClient *mockedKubeClient) EndpointsForRevision(namespace string, serviceName string) (*kubev1.EndpointsList, error) {
-	list := kubev1.EndpointsList{
-		Items: []kubev1.Endpoints{},
-	}
+func (kubeClient *mockedKubeClient) EndpointsForRevision(namespace string, serviceName string) (*kubev1.Endpoints, error) {
+	eps := kubev1.Endpoints{}
 
-	return &list, nil
+	return &eps, nil
 }
 
 func (kubeClient *mockedKubeClient) ServiceForRevision(namespace string, serviceName string) (*kubev1.Service, error) {

--- a/pkg/envoy/listener_test.go
+++ b/pkg/envoy/listener_test.go
@@ -60,7 +60,7 @@ type mockedKubeClientListener struct {
 }
 
 func (kubeClient *mockedKubeClientListener) EndpointsForRevision(
-	namespace string, serviceName string) (*v1.EndpointsList, error) {
+	namespace string, serviceName string) (*v1.Endpoints, error) {
 
 	return nil, nil
 }

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -13,10 +13,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
-const (
-	labelPrefix = "serving.knative.dev/revision="
-)
-
 type KubernetesClient struct {
 	Client *kubernetes.Clientset
 }
@@ -41,9 +37,8 @@ func Config(kubeConfigPath string) *rest.Config {
 	return config
 }
 
-func (kubernetesClient *KubernetesClient) EndpointsForRevision(namespace string, revisionName string) (*v1.EndpointsList, error) {
-	listOptions := meta_v1.ListOptions{LabelSelector: labelPrefix + revisionName}
-	return kubernetesClient.Client.CoreV1().Endpoints(namespace).List(listOptions)
+func (kubernetesClient *KubernetesClient) EndpointsForRevision(namespace string, revisionName string) (*v1.Endpoints, error) {
+	return kubernetesClient.Client.CoreV1().Endpoints(namespace).Get(revisionName, meta_v1.GetOptions{})
 }
 
 func (kubernetesClient *KubernetesClient) ServiceForRevision(namespace string, revisionName string) (*v1.Service, error) {


### PR DESCRIPTION
The private endpoints object is solely for use in Knative Serving internal systems. The activator for example uses it to hit pods directly, the autoscaler to scrape metrics. Ingress should always go via the public endpoints as that is what Knative uses to control if requests flow via the activator or not.