### PR TITLE
Fix CircleCI setup script

### DIFF
--- a/utils/setup-circleci.sh
+++ b/utils/setup-circleci.sh
@@ -21,12 +21,12 @@ chown -R circleci "$HOME"/.kube
 #Builds the kourier image and imports into the k8s cluster
 docker build -t 3scale-kourier:"$tag" ./
 docker image save 3scale-kourier:"$tag" >image.tar
-microk8s.ctr -n k8s.io images import image.tar
+microk8s.ctr --namespace k8s.io images import image.tar
 
 #Builds the gateway image and imports into the k8s cluster
 docker build -f Dockerfile.gateway -t 3scale-kourier-gateway:"$tag" ./
 docker image save 3scale-kourier-gateway:"$tag" >image.tar
-microk8s.ctr -n k8s.io images import image.tar
+microk8s.ctr --namespace k8s.io images import image.tar
 
 # Enable the microk8s DNS plugin
 microk8s.enable dns


### PR DESCRIPTION
"-n" no longer works in the "microk8s.ctr" command. It returns this error when running in circleCI: "ctr: Cannot use two forms of the same flag: n namespace"