### PR TITLE
Push reconciler events for ingresses only when their ingress class is Kourier

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,4 +8,6 @@ const (
 	InternalKourierHeader = "kourier-snapshot-id"
 	InternalKourierDomain = "internalkourier"
 	InternalKourierPath   = "/__internalkouriersnapshot"
+
+	KourierIngressClassName = "kourier.ingress.networking.knative.dev"
 )

--- a/pkg/knative/knative.go
+++ b/pkg/knative/knative.go
@@ -1,6 +1,8 @@
 package knative
 
 import (
+	"kourier/pkg/config"
+
 	"knative.dev/pkg/network"
 	"knative.dev/pkg/system"
 
@@ -11,9 +13,8 @@ import (
 )
 
 const (
-	internalServiceName     = "kourier-internal"
-	externalServiceName     = "kourier-external"
-	kourierIngressClassName = "kourier.ingress.networking.knative.dev"
+	internalServiceName = "kourier-internal"
+	externalServiceName = "kourier-external"
 )
 
 func MarkIngressReady(knativeClient versioned.Interface, ingress *networkingv1alpha1.Ingress) error {
@@ -64,9 +65,7 @@ func FilterByIngressClass(ingresses []*networkingv1alpha1.Ingress) []*networking
 	var res []*networkingv1alpha1.Ingress
 
 	for _, ingress := range ingresses {
-		ingressClass := ingressClass(ingress)
-
-		if ingressClass == kourierIngressClassName {
+		if ingressClass(ingress) == config.KourierIngressClassName {
 			res = append(res, ingress)
 		}
 	}

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -2,7 +2,13 @@ package ingress
 
 import (
 	"context"
+	"kourier/pkg/config"
 	"kourier/pkg/envoy"
+
+	"knative.dev/serving/pkg/apis/networking"
+	"knative.dev/serving/pkg/reconciler"
+
+	"k8s.io/client-go/tools/cache"
 
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
@@ -51,7 +57,16 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		impl.EnqueueKey("")
 	}
 
-	ingressInformer.Informer().AddEventHandler(controller.HandleAll(enqueueFunc))
+	// Ingresses need to be filtered by ingress class, so Kourier does not
+	// react to nor modify ingresses created by other gateways.
+	ingressInformerHandler := cache.FilteringResourceEventHandler{
+		FilterFunc: reconciler.AnnotationFilterFunc(
+			networking.IngressClassAnnotationKey, config.KourierIngressClassName, false,
+		),
+		Handler: controller.HandleAll(enqueueFunc),
+	}
+	ingressInformer.Informer().AddEventHandler(ingressInformerHandler)
+
 	endpointsInformer.Informer().AddEventHandler(controller.HandleAll(enqueueFunc))
 
 	return impl

--- a/pkg/reconciler/ingress/reconciler.go
+++ b/pkg/reconciler/ingress/reconciler.go
@@ -17,12 +17,12 @@ type Reconciler struct {
 }
 
 func (reconciler *Reconciler) Reconcile(ctx context.Context, key string) error {
-	ingressAccessors, err := reconciler.IngressLister.List(labels.Everything())
+	ingresses, err := reconciler.IngressLister.List(labels.Everything())
 	if err != nil {
 		return err
 	}
 
-	kourierIngresses := knative.FilterByIngressClass(ingressAccessors)
+	kourierIngresses := knative.FilterByIngressClass(ingresses)
 
 	reconciler.EnvoyXDSServer.SetSnapshotForIngresses(
 		nodeID,


### PR DESCRIPTION
We were reacting to all changes in ingresses. This PR changes that so we only react to events produced by those ingresses that have the Kourier ingress class.