### PR TITLE
Extract Ingress functionality into its own file

### DIFF
--- a/pkg/envoy/caches.go
+++ b/pkg/envoy/caches.go
@@ -43,8 +43,8 @@ func CachesForIngresses(Ingresses []*v1alpha1.Ingress, kubeclient kubeclient.Int
 	var routeCache []cache.Resource
 
 	for i, ingress := range Ingresses {
-		routeName := getRouteName(ingress)
-		routeNamespace := getRouteNamespace(ingress)
+		routeName := knative.RouteName(ingress)
+		routeNamespace := knative.RouteNamespace(ingress)
 
 		log.WithFields(log.Fields{"name": routeName, "namespace": routeNamespace}).Info("Knative Ingress found")
 
@@ -190,14 +190,6 @@ func internalKourierRoute(snapshotVersion string) route.Route {
 			},
 		},
 	}
-}
-
-func getRouteNamespace(ingress *v1alpha1.Ingress) string {
-	return ingress.GetLabels()["serving.knative.dev/routeNamespace"]
-}
-
-func getRouteName(ingress *v1alpha1.Ingress) string {
-	return ingress.GetLabels()["serving.knative.dev/route"]
 }
 
 func lbEndpointsForKubeEndpoints(kubeEndpoints *kubev1.Endpoints, targetPort int32) (publicLbEndpoints []*endpoint.LbEndpoint) {

--- a/pkg/knative/ingress.go
+++ b/pkg/knative/ingress.go
@@ -5,17 +5,37 @@ import (
 
 	"knative.dev/pkg/network"
 	"knative.dev/pkg/system"
-
-	"knative.dev/serving/pkg/client/clientset/versioned"
-
 	"knative.dev/serving/pkg/apis/networking"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/pkg/client/clientset/versioned"
 )
 
 const (
+	routeNameLabel      = "serving.knative.dev/route"
+	routeNamespaceLabel = "serving.knative.dev/routeNamespace"
 	internalServiceName = "kourier-internal"
 	externalServiceName = "kourier-external"
 )
+
+func FilterByIngressClass(ingresses []*networkingv1alpha1.Ingress) []*networkingv1alpha1.Ingress {
+	var res = make([]*networkingv1alpha1.Ingress, 0)
+
+	for _, ingress := range ingresses {
+		if ingressClass(ingress) == config.KourierIngressClassName {
+			res = append(res, ingress)
+		}
+	}
+
+	return res
+}
+
+func RouteNamespace(ingress *networkingv1alpha1.Ingress) string {
+	return ingress.GetLabels()[routeNamespaceLabel]
+}
+
+func RouteName(ingress *networkingv1alpha1.Ingress) string {
+	return ingress.GetLabels()[routeNameLabel]
+}
 
 func MarkIngressReady(knativeClient versioned.Interface, ingress *networkingv1alpha1.Ingress) error {
 	// TODO: Improve. Currently once we go trough the generation of the envoy cache, we mark the objects as Ready,
@@ -59,18 +79,6 @@ func MarkIngressReady(knativeClient versioned.Interface, ingress *networkingv1al
 		return err
 	}
 	return nil
-}
-
-func FilterByIngressClass(ingresses []*networkingv1alpha1.Ingress) []*networkingv1alpha1.Ingress {
-	var res []*networkingv1alpha1.Ingress
-
-	for _, ingress := range ingresses {
-		if ingressClass(ingress) == config.KourierIngressClassName {
-			res = append(res, ingress)
-		}
-	}
-
-	return res
 }
 
 func ingressClass(ingress *networkingv1alpha1.Ingress) string {

--- a/pkg/knative/ingress_test.go
+++ b/pkg/knative/ingress_test.go
@@ -1,0 +1,79 @@
+package knative
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/serving/pkg/apis/networking"
+	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+)
+
+func TestFilterByIngressClass(t *testing.T) {
+	kourierIngress := networkingv1alpha1.Ingress{
+		ObjectMeta: v1.ObjectMeta{
+			Annotations: map[string]string{
+				networking.IngressClassAnnotationKey: "kourier.ingress.networking.knative.dev",
+			},
+		},
+	}
+
+	unknownIngress := networkingv1alpha1.Ingress{
+		ObjectMeta: v1.ObjectMeta{
+			Annotations: map[string]string{
+				networking.IngressClassAnnotationKey: "unknown",
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		inputIngresses []*networkingv1alpha1.Ingress
+		want           []*networkingv1alpha1.Ingress
+	}{
+		"no input ingresses": {
+			inputIngresses: []*networkingv1alpha1.Ingress{},
+			want:           []*networkingv1alpha1.Ingress{},
+		},
+		"some Kourier ingresses": {
+			inputIngresses: []*networkingv1alpha1.Ingress{&kourierIngress, &unknownIngress},
+			want:           []*networkingv1alpha1.Ingress{&kourierIngress},
+		},
+		"no Kourier ingresses": {
+			inputIngresses: []*networkingv1alpha1.Ingress{&unknownIngress},
+			want:           []*networkingv1alpha1.Ingress{},
+		},
+	}
+
+	for name, data := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := FilterByIngressClass(data.inputIngresses)
+			assert.DeepEqual(t, data.want, got)
+		})
+	}
+}
+
+func TestRouteName(t *testing.T) {
+	routeName := "some_route_name"
+	ingress := networkingv1alpha1.Ingress{
+		ObjectMeta: v1.ObjectMeta{
+			Labels: map[string]string{
+				"serving.knative.dev/route": routeName,
+			},
+		},
+	}
+
+	assert.Equal(t, routeName, RouteName(&ingress))
+}
+
+func TestRouteNamespace(t *testing.T) {
+	routeNamespace := "some_route_namespace"
+	ingress := networkingv1alpha1.Ingress{
+		ObjectMeta: v1.ObjectMeta{
+			Labels: map[string]string{
+				"serving.knative.dev/routeNamespace": routeNamespace,
+			},
+		},
+	}
+
+	assert.Equal(t, routeNamespace, RouteNamespace(&ingress))
+}


### PR DESCRIPTION
This PR extracts all the logic to work with Knative ingresses into its own file. It also adds some unit tests.

I think this change helps us to better organize things, because now in the knative package we have "ingress" and "ingress_rule", which are the Knative entities that we need to work with. We'll no longer have a generic "knative" file.