### PR TITLE
update reprecated envoy config parameters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0 // indirect
 	contrib.go.opencensus.io/exporter/stackdriver v0.12.2 // indirect
-	github.com/envoyproxy/go-control-plane v0.9.0
+	github.com/envoyproxy/go-control-plane v0.9.1
 	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/google/go-containerregistry v0.0.0-20190920214602-53e1ac5a7d18 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,6 @@ github.com/docker/distribution v2.6.0-rc.1.0.20180327202408-83389a148052+incompa
 github.com/docker/docker v1.4.2-0.20180531152204-71cd53e4a197/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/envoyproxy/go-control-plane v0.9.0 h1:67WMNTvGrl7V1dWdKCeTwxDr7nio9clKoTlLhwIPnT4=
-github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1 h1:+8frETDtT11P1dMCWySse/d0jMPOKYYF7OZjl7cZLvQ=
 github.com/envoyproxy/go-control-plane v0.9.1/go.mod h1:G1fbsNGAFpC1aaERrShZQVdUV2ZuZuv6FCl2v9JNSxQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5Xh
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/envoyproxy/go-control-plane v0.9.0 h1:67WMNTvGrl7V1dWdKCeTwxDr7nio9clKoTlLhwIPnT4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
+github.com/envoyproxy/go-control-plane v0.9.1 h1:+8frETDtT11P1dMCWySse/d0jMPOKYYF7OZjl7cZLvQ=
+github.com/envoyproxy/go-control-plane v0.9.1/go.mod h1:G1fbsNGAFpC1aaERrShZQVdUV2ZuZuv6FCl2v9JNSxQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=

--- a/pkg/envoy/caches.go
+++ b/pkg/envoy/caches.go
@@ -28,6 +28,7 @@ type Caches struct {
 	clusters  []cache.Resource
 	routes    []cache.Resource
 	listeners []cache.Resource
+	runtimes  []cache.Resource
 }
 
 // We need this because there might be Envoy clusters used by draining
@@ -153,6 +154,7 @@ func CachesForIngresses(Ingresses []*v1alpha1.Ingress, kubeclient kubeclient.Int
 
 	return Caches{
 		endpoints: []cache.Resource{},
+		runtimes:  []cache.Resource{},
 		clusters:  clustersHistoric.list(),
 		routes:    routeCache,
 		listeners: listenerCache,

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -56,7 +56,7 @@ func (h Hasher) ID(node *core.Node) string {
 func NewEnvoyXdsServer(gatewayPort uint, managementPort uint, kubeClient kubeclient.Interface, knativeClient versioned.Interface) EnvoyXdsServer {
 	ctx := context.Background()
 	snapshotCache := cache.NewSnapshotCache(true, Hasher{}, nil)
-	srv := xds.NewServer(snapshotCache, nil)
+	srv := xds.NewServer(ctx, snapshotCache, nil)
 
 	return EnvoyXdsServer{
 		gatewayPort:    gatewayPort,
@@ -135,6 +135,7 @@ func (envoyXdsServer *EnvoyXdsServer) SetSnapshotForIngresses(nodeId string, Ing
 		caches.clusters,
 		caches.routes,
 		caches.listeners,
+		caches.runtimes,
 	)
 
 	err := envoyXdsServer.snapshotCache.SetSnapshot(nodeId, snapshot)

--- a/pkg/envoy/http_connection_manager.go
+++ b/pkg/envoy/http_connection_manager.go
@@ -12,7 +12,7 @@ import (
 )
 
 func newHttpConnectionManager(virtualHosts []*route.VirtualHost) httpconnectionmanagerv2.HttpConnectionManager {
-	hcm := httpconnectionmanagerv2.HttpConnectionManager{
+	return httpconnectionmanagerv2.HttpConnectionManager{
 		CodecType:  httpconnectionmanagerv2.HttpConnectionManager_AUTO,
 		StatPrefix: "ingress_http",
 		RouteSpecifier: &httpconnectionmanagerv2.HttpConnectionManager_RouteConfig{
@@ -28,8 +28,6 @@ func newHttpConnectionManager(virtualHosts []*route.VirtualHost) httpconnectionm
 		},
 		AccessLog: accessLogs(),
 	}
-
-	return hcm
 }
 
 // Outputs to /dev/stdout using the default format

--- a/pkg/envoy/http_connection_manager.go
+++ b/pkg/envoy/http_connection_manager.go
@@ -3,14 +3,16 @@ package envoy
 import (
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	accesslogv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
+	accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
+	envoy_accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
+	"github.com/golang/protobuf/ptypes"
+
 	httpconnectionmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	pstruct "github.com/golang/protobuf/ptypes/struct"
 )
 
 func newHttpConnectionManager(virtualHosts []*route.VirtualHost) httpconnectionmanagerv2.HttpConnectionManager {
-	return httpconnectionmanagerv2.HttpConnectionManager{
+	hcm := httpconnectionmanagerv2.HttpConnectionManager{
 		CodecType:  httpconnectionmanagerv2.HttpConnectionManager_AUTO,
 		StatPrefix: "ingress_http",
 		RouteSpecifier: &httpconnectionmanagerv2.HttpConnectionManager_RouteConfig{
@@ -24,25 +26,23 @@ func newHttpConnectionManager(virtualHosts []*route.VirtualHost) httpconnectionm
 				Name: wellknown.Router,
 			},
 		},
-
 		AccessLog: accessLogs(),
 	}
+
+	return hcm
 }
 
 // Outputs to /dev/stdout using the default format
-func accessLogs() []*accesslogv2.AccessLog {
-	accessLogConfigFields := make(map[string]*pstruct.Value)
-	accessLogConfigFields["path"] = &pstruct.Value{
-		Kind: &pstruct.Value_StringValue{
-			StringValue: "/dev/stdout",
-		},
-	}
+func accessLogs() []*envoy_accesslog_v2.AccessLog {
+	accessLog, _ := ptypes.MarshalAny(&accesslog_v2.FileAccessLog{
+		Path: "/dev/stdout",
+	})
 
-	return []*accesslogv2.AccessLog{
+	return []*envoy_accesslog_v2.AccessLog{
 		{
 			Name: "envoy.file_access_log",
-			ConfigType: &accesslogv2.AccessLog_Config{
-				Config: &pstruct.Struct{Fields: accessLogConfigFields},
+			ConfigType: &envoy_accesslog_v2.AccessLog_TypedConfig{
+				TypedConfig: accessLog,
 			},
 		},
 	}

--- a/pkg/envoy/listener.go
+++ b/pkg/envoy/listener.go
@@ -93,7 +93,6 @@ func envoyHTTPSListener(manager *httpconnmanagerv2.HttpConnectionManager,
 					Name:       "tls",
 					ConfigType: &core.TransportSocket_TypedConfig{TypedConfig: tlsAny},
 				},
-				Name: "tlsContext",
 			},
 		},
 	}

--- a/pkg/envoy/listener.go
+++ b/pkg/envoy/listener.go
@@ -5,7 +5,8 @@ import (
 	"kourier/pkg/config"
 	"os"
 
-	"github.com/envoyproxy/go-control-plane/pkg/conversion"
+	"github.com/golang/protobuf/ptypes"
+
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -105,7 +106,7 @@ func createAddress(port uint32) *core.Address {
 }
 
 func createFilters(manager *httpconnmanagerv2.HttpConnectionManager) ([]*listener.Filter, error) {
-	pbst, err := conversion.MessageToStruct(manager)
+	managerAny, err := ptypes.MarshalAny(manager)
 	if err != nil {
 		return []*listener.Filter{}, err
 	}
@@ -113,7 +114,7 @@ func createFilters(manager *httpconnmanagerv2.HttpConnectionManager) ([]*listene
 	filters := []*listener.Filter{
 		{
 			Name:       wellknown.HTTPConnectionManager,
-			ConfigType: &listener.Filter_Config{Config: pbst},
+			ConfigType: &listener.Filter_TypedConfig{TypedConfig: managerAny},
 		},
 	}
 


### PR DESCRIPTION
This PR, fixes those deprecations:

* AccessLog
* TLSContext
* HTTPManager parameters

I had to update the envoy go control plane to the latest available version, v0.9.1.