### PR TITLE
Use envoy v1.12.1 to match the current go-control-plane version

### DIFF
--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -1,4 +1,3 @@
-FROM envoyproxy/envoy-alpine:latest
-RUN apk --no-cache add curl
+FROM envoyproxy/envoy-alpine:v1.12.1
 USER 1001
 CMD ["envoy" "-c" "/etc/envoy/envoy.yaml"]

--- a/deploy/knative_e2e_tests/kourier-istio-system.yaml
+++ b/deploy/knative_e2e_tests/kourier-istio-system.yaml
@@ -45,7 +45,7 @@ spec:
         - args:
             - -c
             - /tmp/config/envoy-bootstrap.yaml
-          image: quay.io/3scale/kourier-gateway:v0.1.1
+          image: quay.io/3scale/kourier-gateway:v0.1.2
           imagePullPolicy: Always
           name: kourier-gateway
           ports:
@@ -59,7 +59,7 @@ spec:
               mountPath: /tmp/config
           readinessProbe:
             exec:
-              command: ['ash','-c','curl -H "Host: internalkourier" http://localhost:8081/__internalkouriersnapshot']
+              command: ['ash','-c','(printf "GET /__internalkouriersnapshot HTTP/1.1\r\nHost: internalkourier\r\n\r\n\r\n"; sleep 1) | nc -n localhost 8081 | grep "HTTP/1.1 200 OK"']
             initialDelaySeconds: 5
             periodSeconds: 2
       volumes:

--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -38,7 +38,7 @@ spec:
         - args:
             - -c
             - /tmp/config/envoy-bootstrap.yaml
-          image: quay.io/3scale/kourier-gateway:v0.1.1
+          image: quay.io/3scale/kourier-gateway:v0.1.2
           imagePullPolicy: Always
           name: kourier-gateway
           ports:
@@ -52,7 +52,7 @@ spec:
               mountPath: /tmp/config
           readinessProbe:
             exec:
-              command: ['ash','-c','curl -H "Host: internalkourier" http://localhost:8081/__internalkouriersnapshot']
+              command: ['ash','-c','(printf "GET /__internalkouriersnapshot HTTP/1.1\r\nHost: internalkourier\r\n\r\n"; sleep 1) | nc -n localhost 8081 | grep "HTTP/1.1 200 OK"']
             initialDelaySeconds: 5
             periodSeconds: 2
       volumes:


### PR DESCRIPTION
* Removes the installation of curl from the gateway dockerfile
* Uses netcat to do the http healthcheck instead of curl