### PR TITLE
Avoid doing a full resync when an ingress is deleted

### DIFF
--- a/pkg/envoy/caches_test.go
+++ b/pkg/envoy/caches_test.go
@@ -1,232 +1,137 @@
 package envoy
 
 import (
+	"kourier/pkg/config"
+	"sort"
 	"testing"
 
-	"k8s.io/client-go/kubernetes"
+	"github.com/golang/protobuf/ptypes"
 
-	"k8s.io/client-go/kubernetes/fake"
+	"gotest.tools/assert"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
-	"github.com/envoyproxy/go-control-plane/pkg/cache"
-	"gotest.tools/assert"
-	kubev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	corev1listers "k8s.io/client-go/listers/core/v1"
-	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	httpconnmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	kubeclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
-// Tests that when there is a traffic split defined in the ingress:
-// - Creates a route with weighted clusters defined.
-// - There's one weighted cluster for each traffic split and each contains:
-// 		- The traffic percentage.
-//		- The headers to add (namespace and revision name).
-//		- The cluster name, based on the revision name plus the path.
-// - The weighted clusters exists also in the clusters cache with the same
-//   name.
-//
-// Note: for now, the name of the cluster is the name of the revision plus the
-// path. That might change in the future.
-func TestTrafficSplits(t *testing.T) {
-	ingress := v1alpha1.Ingress{
-		TypeMeta: v1.TypeMeta{
-			Kind:       "Ingress",
-			APIVersion: "networking.internal.knative.dev/v1alpha1",
-		},
-		ObjectMeta: v1.ObjectMeta{
-			Name: "hello-world",
-		},
-		Spec: v1alpha1.IngressSpec{
-			Rules: []v1alpha1.IngressRule{
-				{
-					HTTP: &v1alpha1.HTTPIngressRuleValue{
-						Paths: []v1alpha1.HTTPIngressPath{
-							{
-								Splits: []v1alpha1.IngressBackendSplit{
-									{
-										IngressBackend: v1alpha1.IngressBackend{
-											ServiceNamespace: "default",
-											ServiceName:      "hello-world-rev1",
-											ServicePort: intstr.IntOrString{
-												Type:   intstr.Int,
-												IntVal: 80,
-											},
-										},
-										Percent: 60,
-										AppendHeaders: map[string]string{
-											"Knative-Serving-Namespace": "default",
-											"Knative-Serving-Revision":  "hello-world-rev1",
-										},
-									},
-									{
-										IngressBackend: v1alpha1.IngressBackend{
-											ServiceNamespace: "default",
-											ServiceName:      "hello-world-rev2",
-											ServicePort: intstr.IntOrString{
-												Type:   intstr.Int,
-												IntVal: 80,
-											},
-										},
-										Percent: 40,
-										AppendHeaders: map[string]string{
-											"Knative-Serving-Namespace": "default",
-											"Knative-Serving-Revision":  "hello-world-rev2",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		Status: v1alpha1.IngressStatus{},
-	}
+func TestDeleteIngressInfo(t *testing.T) {
+	caches := NewCaches()
+	kubeClient := fake.Clientset{}
 
-	kubeClient := fake.NewSimpleClientset()
-
-	// Create the Kubernetes services associated to the Knative services that
-	// appear in the ingress above
-	err := createServicesWithNames(
-		kubeClient,
-		[]string{"hello-world-rev1", "hello-world-rev2"},
-		"default",
+	// Add info for an ingress
+	firstIngressName := "ingress_1"
+	firstIngressNamespace := "ingress_1_namespace"
+	createTestDataForIngress(
+		&caches,
+		firstIngressName,
+		firstIngressNamespace,
+		"cluster_for_ingress_1",
+		"route_for_ingress_1",
+		"internal_host_for_ingress_1",
+		"external_host_for_ingress_1",
+		&kubeClient,
 	)
-	if err != nil {
-		t.Error(err)
-	}
 
-	// Check that there is one route in the result
-	caches := CachesForIngresses(
-		[]*v1alpha1.Ingress{&ingress},
-		kubeClient,
-		newMockedEndpointsLister(),
-		"cluster.local",
-		"snapshot-version",
+	// Add info for a different ingress
+	secondIngressName := "ingress_2"
+	secondIngressNamespace := "ingress_2_namespace"
+	createTestDataForIngress(
+		&caches,
+		secondIngressName,
+		secondIngressNamespace,
+		"cluster_for_ingress_2",
+		"route_for_ingress_2",
+		"internal_host_for_ingress_2",
+		"external_host_for_ingress_2",
+		&kubeClient,
 	)
+
+	// Delete the first ingress
+	caches.DeleteIngressInfo(firstIngressName, firstIngressNamespace, &kubeClient)
+
+	// Check that there's only the route of the second ingress
 	assert.Equal(t, 1, len(caches.routes))
+	assert.Equal(t, "route_for_ingress_2", caches.routes[0].Name)
 
-	// Check that there are 2 weighted clusters for the route
-	envoyRoute := caches.routes[0].(*route.Route)
-	weightedClusters := envoyRoute.GetRoute().GetWeightedClusters().Clusters
-	assert.Equal(t, 2, len(weightedClusters))
+	// Check that the listeners only have the virtual hosts of the second
+	// ingress.
+	// Note: Apart from the vHosts that were added explicitly, there's also
+	// the one used to verify the snapshot version.
+	vHostsNames, err := getVHostsNames(caches.listeners)
 
-	// Check the first weighted cluster
-	assertWeightedClusterCorrect(
-		t,
-		weightedClusters[0],
-		"hello-world-rev1/",
-		uint32(60),
-		map[string]string{
-			"Knative-Serving-Namespace": "default",
-			"Knative-Serving-Revision":  "hello-world-rev1",
-		},
+	if err != nil {
+		t.Fail()
+	}
+
+	sort.Strings(vHostsNames)
+
+	expectedNames := []string{
+		"internal_host_for_ingress_2",
+		"external_host_for_ingress_2",
+		config.InternalKourierDomain,
+	}
+	sort.Strings(expectedNames)
+
+	assert.DeepEqual(t, expectedNames, vHostsNames)
+}
+
+// Creates a cluster, a route, and listeners from the given names and
+// associates them with the ingress name/namespace received
+func createTestDataForIngress(caches *Caches,
+	ingressName string,
+	ingressNamespace string,
+	clusterName string,
+	routeName string,
+	internalVHostName string,
+	externalVHostName string,
+	kubeClient kubeclient.Interface) {
+
+	cluster := v2.Cluster{Name: clusterName}
+	caches.AddCluster(&cluster, ingressName, ingressNamespace, "/")
+
+	r := route.Route{Name: routeName}
+	caches.AddRoute(&r, ingressName, ingressNamespace)
+
+	externalvHost := route.VirtualHost{Name: externalVHostName}
+	internalvHost := route.VirtualHost{Name: internalVHostName}
+	listeners := listenersFromVirtualHosts(
+		[]*route.VirtualHost{&externalvHost},
+		[]*route.VirtualHost{&internalvHost},
+		kubeClient,
 	)
 
-	// Check the second weighted cluster
-	assertWeightedClusterCorrect(
-		t,
-		weightedClusters[1],
-		"hello-world-rev2/",
-		uint32(40),
-		map[string]string{
-			"Knative-Serving-Namespace": "default",
-			"Knative-Serving-Revision":  "hello-world-rev2",
-		},
-	)
+	key := mapKey(ingressName, ingressNamespace)
+	localVHostsMappings := make(VHostsForIngresses)
+	localVHostsMappings[key] = []*route.VirtualHost{&internalvHost}
 
-	// Check the clusters cache
-	assert.Equal(
-		t,
-		true,
-		clustersExist([]string{"hello-world-rev1/", "hello-world-rev2/"}, caches.clusters),
-	)
+	externalVHostsMappings := make(VHostsForIngresses)
+	externalVHostsMappings[key] = []*route.VirtualHost{&externalvHost}
+
+	caches.SetListeners(listeners, localVHostsMappings, externalVHostsMappings)
 }
 
-func newMockedEndpointsLister() corev1listers.EndpointsLister {
-	return new(endpointsLister)
-}
+func getVHostsNames(listeners []*v2.Listener) ([]string, error) {
+	var res []string
 
-type endpointsLister struct{}
-
-func (endpointsLister *endpointsLister) List(selector labels.Selector) ([]*kubev1.Endpoints, error) {
-	return []*kubev1.Endpoints{{}}, nil
-}
-
-func (endpointsLister *endpointsLister) Endpoints(namespace string) corev1listers.EndpointsNamespaceLister {
-	return new(endpoints)
-}
-
-type endpoints struct{}
-
-func (endpoints *endpoints) List(selector labels.Selector) ([]*kubev1.Endpoints, error) {
-	return []*kubev1.Endpoints{{}}, nil
-}
-
-func (endpoints *endpoints) Get(name string) (*kubev1.Endpoints, error) {
-	return &kubev1.Endpoints{}, nil
-}
-
-func createServicesWithNames(kubeclient kubernetes.Interface, names []string, namespace string) error {
-	for _, serviceName := range names {
-		service := kubev1.Service{
-			ObjectMeta: v1.ObjectMeta{
-				Name: serviceName,
-			},
-		}
-
-		_, err := kubeclient.CoreV1().Services(namespace).Create(&service)
+	for _, listener := range listeners {
+		filterConfig := listener.GetFilterChains()[0].Filters[0].GetTypedConfig()
+		httpConnManager := httpconnmanagerv2.HttpConnectionManager{}
+		err := ptypes.UnmarshalAny(filterConfig, &httpConnManager)
 
 		if err != nil {
-			return err
+			return nil, err
 		}
-	}
 
-	return nil
-}
+		routeSpecifier := httpConnManager.GetRouteSpecifier()
+		routeConfig := routeSpecifier.(*httpconnmanagerv2.HttpConnectionManager_RouteConfig).RouteConfig
 
-func clustersExist(names []string, clustersCache []cache.Resource) bool {
-	// Cast Resources to Clusters
-	var clusters []*v2.Cluster
-	for _, cacheCluster := range clustersCache {
-		clusters = append(clusters, cacheCluster.(*v2.Cluster))
-	}
-
-	// Create map that contains names that are present
-	present := make(map[string]bool)
-	for _, cacheCluster := range clusters {
-		present[cacheCluster.Name] = true
-	}
-
-	// Verify if the received names are present
-	for _, name := range names {
-		if !present[name] {
-			return false
+		for _, vHost := range routeConfig.VirtualHosts {
+			res = append(res, vHost.Name)
 		}
+
 	}
 
-	return true
-}
-
-// Checks whether the weightedCluster received has the received name, traffic
-// percentage and headers to add
-func assertWeightedClusterCorrect(t *testing.T,
-	weightedCluster *route.WeightedCluster_ClusterWeight,
-	name string,
-	trafficPerc uint32,
-	headersToAdd map[string]string) {
-
-	assert.Equal(t, name, weightedCluster.Name)
-
-	assert.Equal(t, trafficPerc, weightedCluster.Weight.Value)
-
-	// Collect headers for easier comparison
-	clusterHeaders := make(map[string]string)
-	for _, header := range weightedCluster.RequestHeadersToAdd {
-		clusterHeaders[header.Header.Key] = header.Header.Value
-	}
-	assert.DeepEqual(t, clusterHeaders, headersToAdd)
+	return res, nil
 }

--- a/pkg/envoy/generator.go
+++ b/pkg/envoy/generator.go
@@ -1,0 +1,355 @@
+package envoy
+
+import (
+	"kourier/pkg/config"
+	"kourier/pkg/knative"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	log "github.com/sirupsen/logrus"
+	kubev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeclient "k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+)
+
+func CachesForIngresses(Ingresses []*v1alpha1.Ingress, kubeclient kubeclient.Interface, endpointsLister corev1listers.EndpointsLister, localDomainName string) Caches {
+	res := NewCaches()
+
+	var clusterLocalVirtualHosts []*route.VirtualHost
+	var externalVirtualHosts []*route.VirtualHost
+
+	localVHostsMappings := make(VHostsForIngresses)
+	externalVHostsMappings := make(VHostsForIngresses)
+
+	for i, ingress := range Ingresses {
+		routeName := knative.RouteName(ingress)
+		routeNamespace := knative.RouteNamespace(ingress)
+
+		log.WithFields(log.Fields{"name": routeName, "namespace": routeNamespace}).Info("Knative Ingress found")
+
+		for _, rule := range ingress.GetSpec().Rules {
+
+			var ruleRoute []*route.Route
+
+			for _, httpPath := range rule.HTTP.Paths {
+
+				path := "/"
+				if httpPath.Path != "" {
+					path = httpPath.Path
+				}
+
+				var wrs []*route.WeightedCluster_ClusterWeight
+
+				for _, split := range httpPath.Splits {
+
+					headersSplit := split.AppendHeaders
+
+					endpoints, err := endpointsLister.Endpoints(split.ServiceNamespace).Get(split.ServiceName)
+
+					if err != nil {
+						log.Errorf("%s", err)
+						break
+					}
+
+					service, err := kubeclient.CoreV1().Services(split.ServiceNamespace).Get(split.ServiceName, metav1.GetOptions{})
+					if err != nil {
+						log.Errorf("%s", err)
+						break
+					}
+
+					var targetPort int32
+					http2 := false
+					for _, port := range service.Spec.Ports {
+						if port.Port == split.ServicePort.IntVal || port.Name == split.ServicePort.StrVal {
+							targetPort = port.TargetPort.IntVal
+							http2 = port.Name == "http2" || port.Name == "h2c"
+						}
+					}
+
+					publicLbEndpoints := lbEndpointsForKubeEndpoints(endpoints, targetPort)
+
+					connectTimeout := 5 * time.Second
+					cluster := clusterForRevision(split.ServiceName, connectTimeout, publicLbEndpoints, http2, path)
+
+					res.AddCluster(&cluster, split.ServiceName, split.ServiceNamespace, path)
+
+					weightedCluster := weightedCluster(split.ServiceName, uint32(split.Percent), path, headersSplit)
+
+					wrs = append(wrs, &weightedCluster)
+				}
+
+				r := createRouteForRevision(routeName, i, &httpPath, wrs)
+
+				ruleRoute = append(ruleRoute, &r)
+
+				res.AddRoute(&r, ingress.Name, ingress.Namespace)
+			}
+
+			externalDomains := knative.ExternalDomains(&rule, localDomainName)
+			virtualHost := route.VirtualHost{
+				Name:    routeName,
+				Domains: externalDomains,
+				Routes:  ruleRoute,
+			}
+
+			// External should also be accessible internally
+			internalDomains := append(knative.InternalDomains(&rule, localDomainName), externalDomains...)
+			internalVirtualHost := route.VirtualHost{
+				Name:    routeName,
+				Domains: internalDomains,
+				Routes:  ruleRoute,
+			}
+
+			if knative.RuleIsExternal(&rule, ingress.GetSpec().Visibility) {
+				externalVirtualHosts = append(externalVirtualHosts, &virtualHost)
+			}
+
+			clusterLocalVirtualHosts = append(clusterLocalVirtualHosts, &internalVirtualHost)
+
+			key := mapKey(ingress.Name, ingress.Namespace)
+			localVHostsMappings[key] = append(localVHostsMappings[key], &internalVirtualHost)
+			externalVHostsMappings[key] = append(externalVHostsMappings[key], &virtualHost)
+		}
+	}
+
+	// Generate and append the internal kourier route for keeping track of the snapshot id deployed
+	// to each envoy
+	ikr := internalKourierRoute(res.snapshotVersion)
+	ikvh := internalKourierVirtualHost(ikr)
+
+	clusterLocalVirtualHosts = append(clusterLocalVirtualHosts, &ikvh)
+
+	listeners := listenersFromVirtualHosts(
+		externalVirtualHosts,
+		clusterLocalVirtualHosts,
+		kubeclient,
+	)
+
+	res.SetListeners(listeners, localVHostsMappings, externalVHostsMappings)
+
+	return res
+}
+
+func listenersFromVirtualHosts(externalVirtualHosts []*route.VirtualHost,
+	clusterLocalVirtualHosts []*route.VirtualHost,
+	kubeclient kubeclient.Interface) []*v2.Listener {
+
+	externalManager := newHttpConnectionManager(externalVirtualHosts)
+	internalManager := newHttpConnectionManager(clusterLocalVirtualHosts)
+
+	externalEnvoyListener, err := newExternalEnvoyListener(
+		useHTTPSListener(),
+		&externalManager,
+		kubeclient,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	internalEnvoyListener, err := newInternalEnvoyListener(&internalManager)
+	if err != nil {
+		panic(err)
+	}
+
+	return []*v2.Listener{externalEnvoyListener, internalEnvoyListener}
+}
+
+func internalKourierVirtualHost(ikr route.Route) route.VirtualHost {
+	return route.VirtualHost{
+		Name:    config.InternalKourierDomain,
+		Domains: []string{config.InternalKourierDomain},
+		Routes:  []*route.Route{&ikr},
+	}
+}
+
+func internalKourierRoute(snapshotVersion string) route.Route {
+	return route.Route{
+		Name: config.InternalKourierDomain,
+		Match: &route.RouteMatch{
+			PathSpecifier: &route.RouteMatch_Path{
+				Path: config.InternalKourierPath,
+			},
+		},
+		Action: &route.Route_DirectResponse{
+			DirectResponse: &route.DirectResponseAction{Status: http.StatusOK},
+		},
+		ResponseHeadersToAdd: []*core.HeaderValueOption{
+			{
+				Header: &core.HeaderValue{
+					Key:   config.InternalKourierHeader,
+					Value: snapshotVersion,
+				},
+				Append: &wrappers.BoolValue{
+					Value: true,
+				},
+			},
+		},
+	}
+}
+
+func lbEndpointsForKubeEndpoints(kubeEndpoints *kubev1.Endpoints, targetPort int32) (publicLbEndpoints []*endpoint.LbEndpoint) {
+
+	for _, subset := range kubeEndpoints.Subsets {
+
+		for _, address := range subset.Addresses {
+
+			serviceEndpoint := &core.Address{
+				Address: &core.Address_SocketAddress{
+					SocketAddress: &core.SocketAddress{
+						Protocol: core.SocketAddress_TCP,
+						Address:  address.IP,
+						PortSpecifier: &core.SocketAddress_PortValue{
+							PortValue: uint32(targetPort),
+						},
+						Ipv4Compat: true,
+					},
+				},
+			}
+
+			lbEndpoint := endpoint.LbEndpoint{
+				HostIdentifier: &endpoint.LbEndpoint_Endpoint{
+					Endpoint: &endpoint.Endpoint{
+						Address: serviceEndpoint,
+					},
+				},
+			}
+
+			publicLbEndpoints = append(publicLbEndpoints, &lbEndpoint)
+		}
+	}
+
+	return publicLbEndpoints
+}
+
+func createRouteForRevision(routeName string, i int, httpPath *v1alpha1.HTTPIngressPath, wrs []*route.WeightedCluster_ClusterWeight) route.Route {
+	path := "/"
+	if httpPath.Path != "" {
+		path = httpPath.Path
+	}
+
+	var routeTimeout time.Duration
+	if httpPath.Timeout != nil {
+		routeTimeout = httpPath.Timeout.Duration
+	}
+
+	r := route.Route{
+		Name: routeName + "_" + strconv.Itoa(i),
+		Match: &route.RouteMatch{
+			PathSpecifier: &route.RouteMatch_Prefix{
+				Prefix: path,
+			},
+		},
+		Action: &route.Route_Route{Route: &route.RouteAction{
+			ClusterSpecifier: &route.RouteAction_WeightedClusters{
+				WeightedClusters: &route.WeightedCluster{
+					Clusters: wrs,
+				},
+			},
+			Timeout: ptypes.DurationProto(routeTimeout),
+			UpgradeConfigs: []*route.RouteAction_UpgradeConfig{{
+				UpgradeType: "websocket",
+				Enabled:     &wrappers.BoolValue{Value: true},
+			}},
+			RetryPolicy: createRetryPolicyForRoute(httpPath),
+		}},
+		RequestHeadersToAdd: headersToAdd(httpPath.AppendHeaders),
+	}
+
+	return r
+}
+
+func weightedCluster(revisionName string, trafficPerc uint32, path string, headers map[string]string) route.WeightedCluster_ClusterWeight {
+	return route.WeightedCluster_ClusterWeight{
+		Name: revisionName + path,
+		Weight: &wrappers.UInt32Value{
+			Value: trafficPerc,
+		},
+		RequestHeadersToAdd: headersToAdd(headers),
+	}
+}
+
+func headersToAdd(headers map[string]string) []*core.HeaderValueOption {
+	var res []*core.HeaderValueOption
+
+	for headerName, headerVal := range headers {
+		header := core.HeaderValueOption{
+			Header: &core.HeaderValue{
+				Key:   headerName,
+				Value: headerVal,
+			},
+			Append: &wrappers.BoolValue{
+				Value: true,
+			},
+		}
+
+		res = append(res, &header)
+
+	}
+
+	return res
+}
+
+func createRetryPolicyForRoute(httpPath *v1alpha1.HTTPIngressPath) *route.RetryPolicy {
+	attempts := 0
+	var perTryTimeout time.Duration
+	if httpPath.Retries != nil {
+		attempts = httpPath.Retries.Attempts
+
+		if httpPath.Retries.PerTryTimeout != nil {
+			perTryTimeout = httpPath.Retries.PerTryTimeout.Duration
+		}
+	}
+
+	if attempts > 0 {
+		return &route.RetryPolicy{
+			RetryOn: "5xx",
+			NumRetries: &wrappers.UInt32Value{
+				Value: uint32(attempts),
+			},
+			PerTryTimeout: ptypes.DurationProto(perTryTimeout),
+		}
+	} else {
+		return nil
+	}
+}
+
+func clusterForRevision(revisionName string, connectTimeout time.Duration, publicLbEndpoints []*endpoint.LbEndpoint, http2 bool, path string) v2.Cluster {
+
+	cluster := v2.Cluster{
+		Name: revisionName + path,
+		ClusterDiscoveryType: &v2.Cluster_Type{
+			Type: v2.Cluster_STRICT_DNS,
+		},
+		ConnectTimeout: ptypes.DurationProto(connectTimeout),
+		LoadAssignment: &v2.ClusterLoadAssignment{
+			ClusterName: revisionName + path,
+			Endpoints: []*endpoint.LocalityLbEndpoints{
+				{
+					LbEndpoints: publicLbEndpoints,
+					Priority:    1,
+				},
+			},
+		},
+	}
+
+	if http2 {
+		cluster.Http2ProtocolOptions = &core.Http2ProtocolOptions{}
+	}
+
+	return cluster
+}
+
+func useHTTPSListener() bool {
+	return os.Getenv(envCertsSecretNamespace) != "" &&
+		os.Getenv(envCertsSecretName) != ""
+}

--- a/pkg/envoy/generator_test.go
+++ b/pkg/envoy/generator_test.go
@@ -1,0 +1,231 @@
+package envoy
+
+import (
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+
+	"k8s.io/client-go/kubernetes/fake"
+
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/envoyproxy/go-control-plane/pkg/cache"
+	"gotest.tools/assert"
+	kubev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+)
+
+// Tests that when there is a traffic split defined in the ingress:
+// - Creates a route with weighted clusters defined.
+// - There's one weighted cluster for each traffic split and each contains:
+// 		- The traffic percentage.
+//		- The headers to add (namespace and revision name).
+//		- The cluster name, based on the revision name plus the path.
+// - The weighted clusters exists also in the clusters cache with the same
+//   name.
+//
+// Note: for now, the name of the cluster is the name of the revision plus the
+// path. That might change in the future.
+func TestTrafficSplits(t *testing.T) {
+	ingress := v1alpha1.Ingress{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Ingress",
+			APIVersion: "networking.internal.knative.dev/v1alpha1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "hello-world",
+		},
+		Spec: v1alpha1.IngressSpec{
+			Rules: []v1alpha1.IngressRule{
+				{
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{
+							{
+								Splits: []v1alpha1.IngressBackendSplit{
+									{
+										IngressBackend: v1alpha1.IngressBackend{
+											ServiceNamespace: "default",
+											ServiceName:      "hello-world-rev1",
+											ServicePort: intstr.IntOrString{
+												Type:   intstr.Int,
+												IntVal: 80,
+											},
+										},
+										Percent: 60,
+										AppendHeaders: map[string]string{
+											"Knative-Serving-Namespace": "default",
+											"Knative-Serving-Revision":  "hello-world-rev1",
+										},
+									},
+									{
+										IngressBackend: v1alpha1.IngressBackend{
+											ServiceNamespace: "default",
+											ServiceName:      "hello-world-rev2",
+											ServicePort: intstr.IntOrString{
+												Type:   intstr.Int,
+												IntVal: 80,
+											},
+										},
+										Percent: 40,
+										AppendHeaders: map[string]string{
+											"Knative-Serving-Namespace": "default",
+											"Knative-Serving-Revision":  "hello-world-rev2",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: v1alpha1.IngressStatus{},
+	}
+
+	kubeClient := fake.NewSimpleClientset()
+
+	// Create the Kubernetes services associated to the Knative services that
+	// appear in the ingress above
+	err := createServicesWithNames(
+		kubeClient,
+		[]string{"hello-world-rev1", "hello-world-rev2"},
+		"default",
+	)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Check that there is one route in the result
+	caches := CachesForIngresses(
+		[]*v1alpha1.Ingress{&ingress},
+		kubeClient,
+		newMockedEndpointsLister(),
+		"cluster.local",
+	)
+	assert.Equal(t, 1, len(caches.routes))
+
+	// Check that there are 2 weighted clusters for the route
+	envoyRoute := caches.routes[0]
+	weightedClusters := envoyRoute.GetRoute().GetWeightedClusters().Clusters
+	assert.Equal(t, 2, len(weightedClusters))
+
+	// Check the first weighted cluster
+	assertWeightedClusterCorrect(
+		t,
+		weightedClusters[0],
+		"hello-world-rev1/",
+		uint32(60),
+		map[string]string{
+			"Knative-Serving-Namespace": "default",
+			"Knative-Serving-Revision":  "hello-world-rev1",
+		},
+	)
+
+	// Check the second weighted cluster
+	assertWeightedClusterCorrect(
+		t,
+		weightedClusters[1],
+		"hello-world-rev2/",
+		uint32(40),
+		map[string]string{
+			"Knative-Serving-Namespace": "default",
+			"Knative-Serving-Revision":  "hello-world-rev2",
+		},
+	)
+
+	// Check the clusters cache
+	assert.Equal(
+		t,
+		true,
+		clustersExist([]string{"hello-world-rev1/", "hello-world-rev2/"}, caches.clusters.list()),
+	)
+}
+
+func newMockedEndpointsLister() corev1listers.EndpointsLister {
+	return new(endpointsLister)
+}
+
+type endpointsLister struct{}
+
+func (endpointsLister *endpointsLister) List(selector labels.Selector) ([]*kubev1.Endpoints, error) {
+	return []*kubev1.Endpoints{{}}, nil
+}
+
+func (endpointsLister *endpointsLister) Endpoints(namespace string) corev1listers.EndpointsNamespaceLister {
+	return new(endpoints)
+}
+
+type endpoints struct{}
+
+func (endpoints *endpoints) List(selector labels.Selector) ([]*kubev1.Endpoints, error) {
+	return []*kubev1.Endpoints{{}}, nil
+}
+
+func (endpoints *endpoints) Get(name string) (*kubev1.Endpoints, error) {
+	return &kubev1.Endpoints{}, nil
+}
+
+func createServicesWithNames(kubeclient kubernetes.Interface, names []string, namespace string) error {
+	for _, serviceName := range names {
+		service := kubev1.Service{
+			ObjectMeta: v1.ObjectMeta{
+				Name: serviceName,
+			},
+		}
+
+		_, err := kubeclient.CoreV1().Services(namespace).Create(&service)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func clustersExist(names []string, clustersCache []cache.Resource) bool {
+	// Cast Resources to Clusters
+	var clusters []*v2.Cluster
+	for _, cacheCluster := range clustersCache {
+		clusters = append(clusters, cacheCluster.(*v2.Cluster))
+	}
+
+	// Create map that contains names that are present
+	present := make(map[string]bool)
+	for _, cacheCluster := range clusters {
+		present[cacheCluster.Name] = true
+	}
+
+	// Verify if the received names are present
+	for _, name := range names {
+		if !present[name] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Checks whether the weightedCluster received has the received name, traffic
+// percentage and headers to add
+func assertWeightedClusterCorrect(t *testing.T,
+	weightedCluster *route.WeightedCluster_ClusterWeight,
+	name string,
+	trafficPerc uint32,
+	headersToAdd map[string]string) {
+
+	assert.Equal(t, name, weightedCluster.Name)
+
+	assert.Equal(t, trafficPerc, weightedCluster.Weight.Value)
+
+	// Collect headers for easier comparison
+	clusterHeaders := make(map[string]string)
+	for _, header := range weightedCluster.RequestHeadersToAdd {
+		clusterHeaders[header.Header.Key] = header.Header.Value
+	}
+	assert.DeepEqual(t, clusterHeaders, headersToAdd)
+}

--- a/pkg/reconciler/ingress/reconciler.go
+++ b/pkg/reconciler/ingress/reconciler.go
@@ -6,17 +6,86 @@ import (
 	"kourier/pkg/knative"
 
 	"k8s.io/apimachinery/pkg/labels"
+	kubeclient "k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
-	"knative.dev/serving/pkg/client/listers/networking/v1alpha1"
+	"k8s.io/client-go/tools/cache"
+	networkingV1Alpha "knative.dev/serving/pkg/client/listers/networking/v1alpha1"
+)
+
+// Values for the keys received in the reconciler. When they're not a standard
+// "namespace/name".
+const (
+	FullResync     = "full_resync"
+	EndpointChange = "endpoint_change"
+)
+
+type ResyncAction int
+
+const (
+	ResyncAll ResyncAction = iota
+	DeleteIngress
+	NoAction
 )
 
 type Reconciler struct {
-	IngressLister   v1alpha1.IngressLister
+	IngressLister   networkingV1Alpha.IngressLister
 	EndpointsLister corev1listers.EndpointsLister
 	EnvoyXDSServer  envoy.EnvoyXdsServer
+	kubeClient      kubeclient.Interface
+	CurrentCaches   *envoy.Caches
 }
 
 func (reconciler *Reconciler) Reconcile(ctx context.Context, key string) error {
+	action, err := actionNeeded(key, reconciler.IngressLister)
+
+	if err != nil {
+		return err
+	}
+
+	switch action {
+	case ResyncAll:
+		err := reconciler.fullReconcile()
+		if err != nil {
+			return err
+		}
+	case DeleteIngress:
+		ingressNamespace, ingressName, err := cache.SplitMetaNamespaceKey(key)
+
+		if err != nil {
+			return err
+		}
+
+		reconciler.deleteIngress(ingressName, ingressNamespace)
+	}
+
+	return nil
+}
+
+// TODO: For now, it always returns full resync unless it detects that the
+// ingress has been deleted. This should be optimized in the future.
+func actionNeeded(key string, ingressLister networkingV1Alpha.IngressLister) (ResyncAction, error) {
+	if key == FullResync || key == EndpointChange {
+		return ResyncAll, nil
+	}
+
+	ingressNamespace, ingressName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return NoAction, err
+	}
+
+	ingressExists, err := knative.Exists(ingressName, ingressNamespace, ingressLister)
+	if err != nil {
+		return NoAction, err
+	}
+
+	if !ingressExists {
+		return DeleteIngress, nil
+	}
+
+	return ResyncAll, nil
+}
+
+func (reconciler *Reconciler) fullReconcile() error {
 	ingresses, err := reconciler.IngressLister.List(labels.Everything())
 	if err != nil {
 		return err
@@ -24,11 +93,18 @@ func (reconciler *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 	kourierIngresses := knative.FilterByIngressClass(ingresses)
 
-	reconciler.EnvoyXDSServer.SetSnapshotForIngresses(
+	caches := reconciler.EnvoyXDSServer.SetSnapshotForIngresses(
 		nodeID,
 		kourierIngresses,
 		reconciler.EndpointsLister,
 	)
 
+	reconciler.CurrentCaches = caches
+
 	return nil
+}
+
+func (reconciler *Reconciler) deleteIngress(ingressName string, ingressNamespace string) {
+	reconciler.CurrentCaches.DeleteIngressInfo(ingressName, ingressNamespace, reconciler.kubeClient)
+	reconciler.EnvoyXDSServer.SetSnapshotForCaches(reconciler.CurrentCaches, nodeID)
 }


### PR DESCRIPTION
Currently, we are doing a full resync of the config every time we receive an event. We can improve that.

This PR is a first step. It refreshes only parts of the config when an ingress is deleted and also, sets up some structures to make it easier to do similar things for example when an ingress is modified.