### PR TITLE
Update just the modified/added ingress in the config

### DIFF
--- a/pkg/envoy/caches_test.go
+++ b/pkg/envoy/caches_test.go
@@ -96,20 +96,11 @@ func createTestDataForIngress(caches *Caches,
 
 	externalvHost := route.VirtualHost{Name: externalVHostName}
 	internalvHost := route.VirtualHost{Name: internalVHostName}
-	listeners := listenersFromVirtualHosts(
-		[]*route.VirtualHost{&externalvHost},
-		[]*route.VirtualHost{&internalvHost},
-		kubeClient,
-	)
 
-	key := mapKey(ingressName, ingressNamespace)
-	localVHostsMappings := make(VHostsForIngresses)
-	localVHostsMappings[key] = []*route.VirtualHost{&internalvHost}
-
-	externalVHostsMappings := make(VHostsForIngresses)
-	externalVHostsMappings[key] = []*route.VirtualHost{&externalvHost}
-
-	caches.SetListeners(listeners, localVHostsMappings, externalVHostsMappings)
+	caches.AddExternalVirtualHostForIngress(&externalvHost, ingressName, ingressNamespace)
+	caches.AddInternalVirtualHostForIngress(&internalvHost, ingressName, ingressNamespace)
+	caches.AddStatusVirtualHost()
+	caches.SetListeners(kubeClient)
 }
 
 func getVHostsNames(listeners []*v2.Listener) ([]string, error) {

--- a/pkg/reconciler/ingress/reconciler.go
+++ b/pkg/reconciler/ingress/reconciler.go
@@ -5,6 +5,10 @@ import (
 	"kourier/pkg/envoy"
 	"kourier/pkg/knative"
 
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+
+	"knative.dev/pkg/network"
+
 	"k8s.io/apimachinery/pkg/labels"
 	kubeclient "k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -24,6 +28,7 @@ type ResyncAction int
 const (
 	ResyncAll ResyncAction = iota
 	DeleteIngress
+	UpdateIngress
 	NoAction
 )
 
@@ -42,31 +47,40 @@ func (reconciler *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return err
 	}
 
+	ingressNamespace, ingressName, err := cache.SplitMetaNamespaceKey(key)
+
+	if err != nil {
+		return err
+	}
+
 	switch action {
 	case ResyncAll:
 		err := reconciler.fullReconcile()
+
 		if err != nil {
 			return err
 		}
 	case DeleteIngress:
-		ingressNamespace, ingressName, err := cache.SplitMetaNamespaceKey(key)
+		reconciler.deleteIngress(ingressName, ingressNamespace)
+	case UpdateIngress:
+		err = reconciler.updateIngress(ingressName, ingressNamespace)
 
 		if err != nil {
 			return err
 		}
-
-		reconciler.deleteIngress(ingressName, ingressNamespace)
 	}
 
 	return nil
 }
 
-// TODO: For now, it always returns full resync unless it detects that the
-// ingress has been deleted. This should be optimized in the future.
+// TODO: For now, it returns FullResync when an endpoint has been changed. That
+// can be optimized.
 func actionNeeded(key string, ingressLister networkingV1Alpha.IngressLister) (ResyncAction, error) {
 	if key == FullResync || key == EndpointChange {
 		return ResyncAll, nil
 	}
+
+	// At this point we know that the event has been caused by an ingress.
 
 	ingressNamespace, ingressName, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
@@ -82,7 +96,7 @@ func actionNeeded(key string, ingressLister networkingV1Alpha.IngressLister) (Re
 		return DeleteIngress, nil
 	}
 
-	return ResyncAll, nil
+	return UpdateIngress, nil
 }
 
 func (reconciler *Reconciler) fullReconcile() error {
@@ -107,4 +121,29 @@ func (reconciler *Reconciler) fullReconcile() error {
 func (reconciler *Reconciler) deleteIngress(ingressName string, ingressNamespace string) {
 	reconciler.CurrentCaches.DeleteIngressInfo(ingressName, ingressNamespace, reconciler.kubeClient)
 	reconciler.EnvoyXDSServer.SetSnapshotForCaches(reconciler.CurrentCaches, nodeID)
+}
+
+func (reconciler *Reconciler) updateIngress(ingressName string, ingressNamespace string) error {
+	ingress, err := reconciler.IngressLister.Ingresses(ingressNamespace).Get(ingressName)
+
+	if err != nil {
+		return err
+	}
+
+	envoy.UpdateInfoForIngress(
+		reconciler.CurrentCaches,
+		ingress,
+		reconciler.kubeClient,
+		reconciler.EndpointsLister,
+		network.GetClusterDomainName(),
+	)
+
+	reconciler.EnvoyXDSServer.SetSnapshotForCaches(reconciler.CurrentCaches, nodeID)
+
+	reconciler.EnvoyXDSServer.MarkIngressesReady(
+		[]*v1alpha1.Ingress{ingress},
+		reconciler.CurrentCaches.SnapshotVersion(),
+	)
+
+	return nil
 }


### PR DESCRIPTION
This PR continues the work started in #125 

Instead of generating the whole Envoy config when there's a change in an ingress, or when an ingress is added, this PR makes some changes so only the part of the config that belongs to that ingress is generated without modifying the rest.