### PR TITLE
Improve Caches initialization in the reconciler

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -47,11 +47,14 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	ingressInformer := ingressinformer.Get(ctx)
 	endpointsInformer := endpointsinformer.Get(ctx)
 
+	caches := envoy.NewCaches()
+
 	c := &Reconciler{
 		IngressLister:   ingressInformer.Lister(),
 		EndpointsLister: endpointsInformer.Lister(),
 		EnvoyXDSServer:  envoyXdsServer,
 		kubeClient:      kubernetesClient,
+		CurrentCaches:   &caches,
 	}
 	impl := controller.NewImpl(c, logger, controllerName)
 


### PR DESCRIPTION
This PR:
- Ensures that the Caches structure is initialized when instantiating the reconciler. That's so we do not have to worry about whether it's nil or not in the rest of the code.
- Ensures that a full resync is the first event triggered.