### PR TITLE
Clean up some unnecessary helper functions.

### DIFF
--- a/pkg/envoy/generator.go
+++ b/pkg/envoy/generator.go
@@ -79,10 +79,7 @@ func addIngressToCaches(caches *Caches,
 	var clusterLocalVirtualHosts []*route.VirtualHost
 	var externalVirtualHosts []*route.VirtualHost
 
-	routeName := knative.RouteName(ingress)
-	routeNamespace := knative.RouteNamespace(ingress)
-
-	log.WithFields(log.Fields{"name": routeName, "namespace": routeNamespace}).Info("Knative Ingress found")
+	log.WithFields(log.Fields{"name": ingress.Name, "namespace": ingress.Namespace}).Info("Knative Ingress found")
 
 	for _, rule := range ingress.GetSpec().Rules {
 
@@ -149,7 +146,7 @@ func addIngressToCaches(caches *Caches,
 				wrs = append(wrs, &weightedCluster)
 			}
 
-			r := createRouteForRevision(routeName, index, &httpPath, wrs)
+			r := createRouteForRevision(ingress.Name, index, &httpPath, wrs)
 
 			ruleRoute = append(ruleRoute, &r)
 
@@ -158,7 +155,7 @@ func addIngressToCaches(caches *Caches,
 
 		externalDomains := knative.ExternalDomains(&rule, localDomainName)
 		virtualHost := route.VirtualHost{
-			Name:    routeName,
+			Name:    ingress.Name,
 			Domains: externalDomains,
 			Routes:  ruleRoute,
 		}
@@ -166,7 +163,7 @@ func addIngressToCaches(caches *Caches,
 		// External should also be accessible internally
 		internalDomains := append(knative.InternalDomains(&rule, localDomainName), externalDomains...)
 		internalVirtualHost := route.VirtualHost{
-			Name:    routeName,
+			Name:    ingress.Name,
 			Domains: internalDomains,
 			Routes:  ruleRoute,
 		}

--- a/pkg/knative/ingress.go
+++ b/pkg/knative/ingress.go
@@ -3,9 +3,6 @@ package knative
 import (
 	"kourier/pkg/config"
 
-	"knative.dev/serving/pkg/client/listers/networking/v1alpha1"
-
-	"k8s.io/apimachinery/pkg/api/errors"
 	"knative.dev/pkg/network"
 	"knative.dev/pkg/system"
 	"knative.dev/serving/pkg/apis/networking"
@@ -14,8 +11,6 @@ import (
 )
 
 const (
-	routeNameLabel      = "serving.knative.dev/route"
-	routeNamespaceLabel = "serving.knative.dev/routeNamespace"
 	internalServiceName = "kourier-internal"
 	externalServiceName = "kourier-external"
 )
@@ -30,29 +25,6 @@ func FilterByIngressClass(ingresses []*networkingv1alpha1.Ingress) []*networking
 	}
 
 	return res
-}
-
-func RouteNamespace(ingress *networkingv1alpha1.Ingress) string {
-	return ingress.GetLabels()[routeNamespaceLabel]
-}
-
-func RouteName(ingress *networkingv1alpha1.Ingress) string {
-	return ingress.GetLabels()[routeNameLabel]
-}
-
-func Exists(ingressName string, ingressNamespace string, ingressLister v1alpha1.IngressLister) (bool, error) {
-	_, err := ingressLister.Ingresses(ingressNamespace).Get(ingressName)
-
-	notFoundErr := errors.NewNotFound(networkingv1alpha1.Resource("ingress"), ingressName).Error()
-
-	if err != nil {
-		if err.Error() == notFoundErr {
-			return false, nil
-		}
-		return false, err
-	}
-
-	return true, nil
 }
 
 func MarkIngressReady(knativeClient versioned.Interface, ingress *networkingv1alpha1.Ingress) error {

--- a/pkg/knative/ingress_test.go
+++ b/pkg/knative/ingress_test.go
@@ -51,29 +51,3 @@ func TestFilterByIngressClass(t *testing.T) {
 		})
 	}
 }
-
-func TestRouteName(t *testing.T) {
-	routeName := "some_route_name"
-	ingress := networkingv1alpha1.Ingress{
-		ObjectMeta: v1.ObjectMeta{
-			Labels: map[string]string{
-				"serving.knative.dev/route": routeName,
-			},
-		},
-	}
-
-	assert.Equal(t, routeName, RouteName(&ingress))
-}
-
-func TestRouteNamespace(t *testing.T) {
-	routeNamespace := "some_route_namespace"
-	ingress := networkingv1alpha1.Ingress{
-		ObjectMeta: v1.ObjectMeta{
-			Labels: map[string]string{
-				"serving.knative.dev/routeNamespace": routeNamespace,
-			},
-		},
-	}
-
-	assert.Equal(t, routeNamespace, RouteNamespace(&ingress))
-}

--- a/pkg/reconciler/ingress/reconciler.go
+++ b/pkg/reconciler/ingress/reconciler.go
@@ -52,7 +52,8 @@ func (reconciler *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return err
 	}
 
-	return reconciler.updateIngress(ingress)
+	reconciler.updateIngress(ingress)
+	return nil
 }
 
 func (reconciler *Reconciler) fullReconcile() error {
@@ -80,7 +81,7 @@ func (reconciler *Reconciler) deleteIngress(namespace, name string) {
 	reconciler.EnvoyXDSServer.SetSnapshotForCaches(reconciler.CurrentCaches, nodeID)
 }
 
-func (reconciler *Reconciler) updateIngress(ingress *v1alpha1.Ingress) error {
+func (reconciler *Reconciler) updateIngress(ingress *v1alpha1.Ingress) {
 	envoy.UpdateInfoForIngress(
 		reconciler.CurrentCaches,
 		ingress,
@@ -96,6 +97,4 @@ func (reconciler *Reconciler) updateIngress(ingress *v1alpha1.Ingress) error {
 		[]*v1alpha1.Ingress{ingress},
 		reconciler.CurrentCaches.SnapshotVersion(),
 	)
-
-	return nil
 }


### PR DESCRIPTION
Just some things I noticed while scanning the code again.

1. We don't need to deal with "Route" shenanigans at all I think? Our central piece of information should always be Ingress. They are probably named the same anyway so 🤷‍♂ , might as well just ditch the helpers.
2. We can determine if something exists or not by using the `IsNotFound` check on the error returned by a GET operation. This redoes some bits of the reconciler setup to be able to just do one GET for the whole cycle.