### PR TITLE
Ingress statusManager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	go.opencensus.io v0.22.2 // indirect
 	go.uber.org/atomic v1.5.1 // indirect
 	go.uber.org/multierr v1.4.0 // indirect
-	go.uber.org/zap v1.13.0 // indirect
+	go.uber.org/zap v1.13.0
 	golang.org/x/crypto v0.0.0-20191128160524-b544559bb6d1 // indirect
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
 	golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933 // indirect

--- a/pkg/envoy/caches.go
+++ b/pkg/envoy/caches.go
@@ -89,7 +89,7 @@ func (caches *Caches) AddStatusVirtualHost() {
 		ingresses = append(ingresses, val)
 	}
 
-	ikrs := internalKourierRoute(ingresses)
+	ikrs := internalKourierRoutes(ingresses)
 	ikvh := internalKourierVirtualHost(ikrs)
 	caches.statusVirtualHost = &ikvh
 }
@@ -156,7 +156,7 @@ func (caches *Caches) DeleteIngressInfo(ingressName string, ingressNamespace str
 		ingresses = append(ingresses, val)
 	}
 
-	ikr := internalKourierRoute(ingresses)
+	ikr := internalKourierRoutes(ingresses)
 	ikvh := internalKourierVirtualHost(ikr)
 	newClusterLocalVirtualHosts = append(newClusterLocalVirtualHosts, &ikvh)
 

--- a/pkg/envoy/generator.go
+++ b/pkg/envoy/generator.go
@@ -1,6 +1,7 @@
 package envoy
 
 import (
+	"fmt"
 	"kourier/pkg/config"
 	"kourier/pkg/knative"
 	"net/http"
@@ -22,6 +23,7 @@ import (
 	kubeclient "k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/pkg/reconciler/ingress/resources"
 )
 
 // For now, when updating the info for an ingress we delete it, and then
@@ -58,6 +60,8 @@ func addIngressToCaches(caches *Caches,
 
 	var clusterLocalVirtualHosts []*route.VirtualHost
 	var externalVirtualHosts []*route.VirtualHost
+
+	caches.AddIngress(ingress)
 
 	log.WithFields(log.Fields{"name": ingress.Name, "namespace": ingress.Namespace}).Info("Knative Ingress found")
 
@@ -188,16 +192,43 @@ func listenersFromVirtualHosts(externalVirtualHosts []*route.VirtualHost,
 	return []*v2.Listener{externalEnvoyListener, internalEnvoyListener}
 }
 
-func internalKourierVirtualHost(ikr route.Route) route.VirtualHost {
+func internalKourierVirtualHost(ikrs []*route.Route) route.VirtualHost {
 	return route.VirtualHost{
 		Name:    config.InternalKourierDomain,
 		Domains: []string{config.InternalKourierDomain},
-		Routes:  []*route.Route{&ikr},
+		Routes:  ikrs,
 	}
 }
 
-func internalKourierRoute(snapshotVersion string) route.Route {
-	return route.Route{
+func internalKourierRoute(ingresses []*v1alpha1.Ingress) []*route.Route {
+
+	var hashes []string
+	var routes []*route.Route
+	for _, ingress := range ingresses {
+		hash, err := resources.ComputeIngressHash(ingress)
+		if err != nil {
+			log.Errorf("Failed to hash ingress %s: %s", ingress.Name, err)
+			break
+		}
+		hashes = append(hashes, fmt.Sprintf("%x", hash))
+	}
+
+	for _, hash := range hashes {
+		r := route.Route{
+			Name: fmt.Sprintf("%s_%s", config.InternalKourierDomain, hash),
+			Match: &route.RouteMatch{
+				PathSpecifier: &route.RouteMatch_Path{
+					Path: fmt.Sprintf("%s/%s", config.InternalKourierPath, hash),
+				},
+			},
+			Action: &route.Route_DirectResponse{
+				DirectResponse: &route.DirectResponseAction{Status: http.StatusOK},
+			},
+		}
+		routes = append(routes, &r)
+	}
+
+	staticRoute := route.Route{
 		Name: config.InternalKourierDomain,
 		Match: &route.RouteMatch{
 			PathSpecifier: &route.RouteMatch_Path{
@@ -207,18 +238,11 @@ func internalKourierRoute(snapshotVersion string) route.Route {
 		Action: &route.Route_DirectResponse{
 			DirectResponse: &route.DirectResponseAction{Status: http.StatusOK},
 		},
-		ResponseHeadersToAdd: []*core.HeaderValueOption{
-			{
-				Header: &core.HeaderValue{
-					Key:   config.InternalKourierHeader,
-					Value: snapshotVersion,
-				},
-				Append: &wrappers.BoolValue{
-					Value: true,
-				},
-			},
-		},
 	}
+
+	routes = append(routes, &staticRoute)
+
+	return routes
 }
 
 func lbEndpointsForKubeEndpoints(kubeEndpoints *kubev1.Endpoints, targetPort int32) (publicLbEndpoints []*endpoint.LbEndpoint) {

--- a/pkg/envoy/generator.go
+++ b/pkg/envoy/generator.go
@@ -200,7 +200,7 @@ func internalKourierVirtualHost(ikrs []*route.Route) route.VirtualHost {
 	}
 }
 
-func internalKourierRoute(ingresses []*v1alpha1.Ingress) []*route.Route {
+func internalKourierRoutes(ingresses []*v1alpha1.Ingress) []*route.Route {
 
 	var hashes []string
 	var routes []*route.Route

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -46,7 +46,11 @@ func (reconciler *Reconciler) Reconcile(ctx context.Context, key string) error {
 }
 
 func (reconciler *Reconciler) deleteIngress(namespace, name string) {
+
 	ingress := reconciler.CurrentCaches.GetIngress(name, namespace)
+
+	// We need to check for ingress not being nil, because we can receive an event from an already
+	// removed ingress, like for example, when the endpoints object for that ingress is updated/removed.
 	if ingress != nil {
 		reconciler.statusManager.CancelIngress(ingress)
 	}

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -1,0 +1,372 @@
+/*
+   Copyright 2019 The Knative Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ingress
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"kourier/pkg/config"
+	"net"
+	"net/http"
+	"reflect"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"knative.dev/serving/pkg/reconciler/ingress/resources"
+
+	"knative.dev/pkg/system"
+
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+
+	"go.uber.org/zap"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/wait"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/util/workqueue"
+
+	"knative.dev/serving/pkg/network/prober"
+)
+
+const (
+	probeConcurrency          = 5
+	probeInterval             = 1 * time.Second
+	stateExpiration           = 5 * time.Minute
+	cleanupPeriod             = 1 * time.Minute
+	gatewayLabelSelectorKey   = "app"
+	gatewayLabelSelectorValue = "3scale-kourier-gateway"
+)
+
+var dialContext = (&net.Dialer{}).DialContext
+
+// IngressState represents the probing progress at the Ingress scope
+type IngressState struct {
+	id      string
+	ingress *v1alpha1.Ingress
+	// pendingCount is the number of pods that haven't been successfully probed yet
+	pendingCount int32
+	lastAccessed time.Time
+
+	cancel func()
+}
+
+// podState represents the probing progress at the Pod scope
+type podState struct {
+	successCount int32
+
+	context context.Context
+	cancel  func()
+}
+
+type workItem struct {
+	ingressState *IngressState
+	podState     *podState
+	url          string
+	podIP        string
+	hostname     string
+}
+
+// StatusManager provides a way to check if a VirtualService is ready
+type StatusManager interface {
+	IsReady(snapshotID string) (bool, error)
+}
+
+// StatusProber provides a way to check if a VirtualService is ready by probing the Envoy pods
+// handling that VirtualService.
+type StatusProber struct {
+	logger *zap.SugaredLogger
+
+	// mu guards snapshotStates and podStates
+	mu            sync.Mutex
+	ingressStates map[string]*IngressState
+	podStates     map[string]*podState
+
+	workQueue workqueue.RateLimitingInterface
+	podLister corev1listers.PodLister
+
+	readyCallback    func(ingress *v1alpha1.Ingress)
+	probeConcurrency int
+	stateExpiration  time.Duration
+	cleanupPeriod    time.Duration
+}
+
+// NewStatusProber creates a new instance of StatusProber
+func NewStatusProber(
+	logger *zap.SugaredLogger,
+	podLister corev1listers.PodLister,
+	readyCallback func(ingress *v1alpha1.Ingress)) *StatusProber {
+	return &StatusProber{
+		logger:        logger,
+		ingressStates: make(map[string]*IngressState),
+		podStates:     make(map[string]*podState),
+		workQueue: workqueue.NewNamedRateLimitingQueue(
+			workqueue.DefaultControllerRateLimiter(),
+			"ProbingQueue"),
+		readyCallback:    readyCallback,
+		podLister:        podLister,
+		probeConcurrency: probeConcurrency,
+		stateExpiration:  stateExpiration,
+		cleanupPeriod:    cleanupPeriod,
+	}
+}
+
+// IsReady checks if the provided Ingress is ready, i.e. the Envoy pods serving the Ingress
+// have all been updated. This function is designed to be used by the Ingress controller, i.e. it
+// will be called in the order of reconciliation. This means that if IsReady is called on an Ingress,
+// this Ingress is the latest known version and therefore anything related to older versions can be ignored.
+// Also, it means that IsReady is not called concurrently.
+func (m *StatusProber) IsReady(ingress *v1alpha1.Ingress) (bool, error) {
+
+	hash, err := resources.ComputeIngressHash(ingress)
+	if err != nil {
+		return false, err
+	}
+
+	ingressKey := fmt.Sprintf("%x", hash)
+
+	if ready, ok := func() (bool, bool) {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		if state, ok := m.ingressStates[ingressKey]; ok {
+			if state.id == ingressKey {
+				state.lastAccessed = time.Now()
+				return atomic.LoadInt32(&state.pendingCount) == 0, true
+			}
+
+			// Cancel the polling for the outdated version
+			state.cancel()
+			delete(m.ingressStates, ingressKey)
+		}
+		return false, false
+	}(); ok {
+		return ready, nil
+	}
+
+	ingCtx, cancel := context.WithCancel(context.Background())
+	snapshotState := &IngressState{
+		id:           ingressKey,
+		ingress:      ingress,
+		pendingCount: 0,
+		lastAccessed: time.Now(),
+		cancel:       cancel,
+	}
+
+	var workItems []*workItem
+	selector := labels.NewSelector()
+	labelSelector, err := labels.NewRequirement(gatewayLabelSelectorKey, selection.Equals, []string{gatewayLabelSelectorValue})
+	if err != nil {
+		m.logger.Errorf("Failed to create 'Equals' requirement from %q=%q: %w", gatewayLabelSelectorKey, gatewayLabelSelectorValue, err)
+	}
+	selector = selector.Add(*labelSelector)
+
+	gatewayPods, err := m.podLister.Pods(system.Namespace()).List(selector)
+	if err != nil {
+		m.logger.Errorf("failed to get gateway pods: %w", err)
+	}
+
+	if len(gatewayPods) == 0 {
+		return false, nil
+	}
+
+	for _, gwPod := range gatewayPods {
+		ip := gwPod.Status.PodIP
+		ctx, cancel := context.WithCancel(ingCtx)
+		podState := &podState{
+			successCount: 0,
+			context:      ctx,
+			cancel:       cancel,
+		}
+		// Save the podState to be able to cancel it in case of Pod deletion
+		func() {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			m.podStates[ip] = podState
+		}()
+
+		// Update states and cleanup m.podStates when probing is done or cancelled
+		go func(ip string) {
+			<-podState.context.Done()
+			m.updateStates(snapshotState, podState)
+
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			// It is critical to check that the current podState is also the one stored in the map
+			// before deleting it because it could have been replaced if a new version of the ingress
+			// has started being probed.
+			if state, ok := m.podStates[ip]; ok && state == podState {
+				delete(m.podStates, ip)
+			}
+		}(ip)
+
+		port := strconv.Itoa(int(config.HttpPortInternal))
+
+		workItem := &workItem{
+			ingressState: snapshotState,
+			podState:     podState,
+			url:          "http://" + gwPod.Status.PodIP + ":" + port + config.InternalKourierPath + "/" + ingressKey,
+			podIP:        ip,
+			hostname:     config.InternalKourierDomain,
+		}
+		workItems = append(workItems, workItem)
+
+	}
+
+	snapshotState.pendingCount += int32(len(gatewayPods))
+
+	func() {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		m.ingressStates[ingressKey] = snapshotState
+	}()
+	for _, workItem := range workItems {
+		m.workQueue.AddRateLimited(workItem)
+		m.logger.Infof("Queuing probe for %s, IP: %s (depth: %d)", workItem.url, workItem.podIP, m.workQueue.Len())
+	}
+	return len(workItems) == 0, nil
+}
+
+// Start starts the StatusManager background operations
+func (m *StatusProber) Start(done <-chan struct{}) {
+	// Start the worker goroutines
+	for i := 0; i < m.probeConcurrency; i++ {
+		go func() {
+			for m.processWorkItem() {
+			}
+		}()
+	}
+
+	// Cleanup the states periodically
+	go wait.Until(m.expireOldStates, m.cleanupPeriod, done)
+
+	// Stop processing the queue when cancelled
+	go func() {
+		<-done
+		m.workQueue.ShutDown()
+	}()
+}
+
+// CancelIngress cancels probing of the provided Ingress.
+func (m *StatusProber) CancelIngress(ingress *v1alpha1.Ingress) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	hash, err := resources.ComputeIngressHash(ingress)
+	if err != nil {
+		logrus.Error("failed to compute ingress Hash: %s", err)
+	}
+	ingressKey := fmt.Sprintf("%x", hash)
+	if state, ok := m.ingressStates[ingressKey]; ok {
+		state.cancel()
+	}
+}
+
+// CancelPodProbing cancels probing of the provided Pod IP.
+func (m *StatusProber) CancelPodProbing(pod *corev1.Pod) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if state, ok := m.podStates[pod.Status.PodIP]; ok {
+		state.cancel()
+	}
+}
+
+// expireOldStates removes the states that haven't been accessed in a while.
+func (m *StatusProber) expireOldStates() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for key, state := range m.ingressStates {
+		if time.Since(state.lastAccessed) > m.stateExpiration {
+			state.cancel()
+			delete(m.ingressStates, key)
+		}
+	}
+}
+
+// processWorkItem processes a single work item from workQueue.
+// It returns false when there is no more items to process, true otherwise.
+func (m *StatusProber) processWorkItem() bool {
+	obj, shutdown := m.workQueue.Get()
+	if shutdown {
+		return false
+	}
+
+	defer m.workQueue.Done(obj)
+
+	// Crash if the item is not of the expected type
+	item, ok := obj.(*workItem)
+	if !ok {
+		m.logger.Fatalf("Unexpected work item type: want: %s, got: %s\n", reflect.TypeOf(&workItem{}).Name(), reflect.TypeOf(obj).Name())
+	}
+	m.logger.Infof("Processing probe for %s, IP: %s (depth: %d)", item.url, item.podIP, m.workQueue.Len())
+
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			// We only want to know that the Gateway is configured, not that the configuration is valid.
+			// Therefore, we can safely ignore any TLS certificate validation.
+			InsecureSkipVerify: true,
+		},
+		DisableKeepAlives: true,
+		DialContext: func(ctx context.Context, network, addr string) (conn net.Conn, e error) {
+			// Requests with the IP as hostname and the Host header set do no pass client-side validation
+			// because the HTTP client validates that the hostname (not the Host header) matches the server
+			// TLS certificate Common Name or Alternative Names. Therefore, http.Request.URL is set to the
+			// hostname and it is substituted it here with the target IP.
+			return dialContext(ctx, network, net.JoinHostPort(item.podIP, strconv.Itoa(int(config.HttpPortInternal))))
+		}}
+
+	ok, err := prober.Do(
+		item.podState.context,
+		transport,
+		item.url,
+		prober.WithHost(config.InternalKourierDomain),
+		prober.ExpectsStatusCodes([]int{http.StatusOK}),
+	)
+
+	// In case of cancellation, drop the work item
+	select {
+	case <-item.podState.context.Done():
+		m.workQueue.Forget(obj)
+		return true
+	default:
+	}
+
+	if err != nil || !ok {
+		// In case of error, enqueue for retry
+		m.workQueue.AddRateLimited(obj)
+		m.logger.Errorf("Probing of %s failed, IP: %s, ready: %t, error: %v (depth: %d)", item.url, item.podIP, ok, err, m.workQueue.Len())
+	} else {
+		m.updateStates(item.ingressState, item.podState)
+	}
+	return true
+}
+
+func (m *StatusProber) updateStates(ingressState *IngressState, podState *podState) {
+	if atomic.AddInt32(&podState.successCount, 1) == 1 {
+		// This is the first successful probe call for the pod, cancel all other work items for this pod
+		podState.cancel()
+
+		// This is the last pod being successfully probed, the Ingress is ready
+		if atomic.AddInt32(&ingressState.pendingCount, -1) == 0 {
+			m.readyCallback(ingressState.ingress)
+		}
+	}
+}

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -29,8 +29,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"knative.dev/serving/pkg/reconciler/ingress/resources"
 
 	"knative.dev/pkg/system"
@@ -272,7 +270,7 @@ func (m *StatusProber) CancelIngress(ingress *v1alpha1.Ingress) {
 	defer m.mu.Unlock()
 	hash, err := resources.ComputeIngressHash(ingress)
 	if err != nil {
-		logrus.Error("failed to compute ingress Hash: %s", err)
+		m.logger.Errorf("failed to compute ingress Hash: %s", err)
 	}
 	ingressKey := fmt.Sprintf("%x", hash)
 	if state, ok := m.ingressStates[ingressKey]; ok {


### PR DESCRIPTION
* Handle Ingresses readiness asynchronously. 
* Creates one path for each ingress in the internal kourier gateway service. We can track ingresses readiness individually.

We should create a new release before merging this PR to test the current changes. Then, a new Release with this PR merged so we can identify what breaks what. 