### PR TITLE
Rework cluster cache to allow expires

### DIFF
--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -56,9 +56,9 @@ func (caches *Caches) DeleteIngress(ingressName, ingressNamespace string) {
 	delete(caches.clustersToIngress, mapKey(ingressName, ingressNamespace))
 }
 
-func (caches *Caches) AddCluster(cluster *v2.Cluster, serviceName string, serviceNamespace string, path string) {
-	caches.clusters.set(serviceName, path, serviceNamespace, cluster)
-	caches.addClustersForIngress(cluster, serviceName, serviceNamespace)
+func (caches *Caches) AddCluster(cluster *v2.Cluster, ingressName string, ingressNamespace string) {
+	caches.clusters.set(cluster, ingressName, ingressNamespace)
+	caches.addClustersForIngress(cluster, ingressName, ingressNamespace)
 }
 
 func (caches *Caches) AddRoute(route *route.Route, ingressName string, ingressNamespace string) {
@@ -162,7 +162,7 @@ func (caches *Caches) DeleteIngressInfo(ingressName string, ingressNamespace str
 	// Set to expire all the clusters belonging to that Ingress.
 	clusters := caches.clustersToIngress[mapKey(ingressName, ingressNamespace)]
 	for _, cluster := range clusters {
-		caches.clusters.setExpiration(cluster)
+		caches.clusters.setExpiration(cluster, ingressName, ingressNamespace)
 	}
 
 	caches.DeleteIngress(ingressName, ingressNamespace)

--- a/pkg/generator/caches_test.go
+++ b/pkg/generator/caches_test.go
@@ -89,7 +89,7 @@ func createTestDataForIngress(caches *Caches,
 	kubeClient kubeclient.Interface) {
 
 	cluster := v2.Cluster{Name: clusterName}
-	caches.AddCluster(&cluster, ingressName, ingressNamespace, "/")
+	caches.AddCluster(&cluster, ingressName, ingressNamespace)
 
 	r := route.Route{Name: routeName}
 	caches.AddRoute(&r, ingressName, ingressNamespace)

--- a/pkg/generator/cluster_cache.go
+++ b/pkg/generator/cluster_cache.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoycache "github.com/envoyproxy/go-control-plane/pkg/cache"
 	gocache "github.com/patrickmn/go-cache"
 )
@@ -43,13 +44,14 @@ func newClustersCacheWithExpAndCleanupIntervals(expiration time.Duration, cleanu
 	return ClustersCache{clusters: goCache}
 }
 
-func (cc *ClustersCache) set(serviceWithRevisionName string, path string, namespace string, cluster envoycache.Resource) {
-	key := key(serviceWithRevisionName, path, namespace)
+func (cc *ClustersCache) set(cluster *v2.Cluster, ingressName string, ingressNamespace string) {
+	key := key(cluster.Name, ingressName, ingressNamespace)
 	cc.clusters.Set(key, cluster, defaultExpiration)
 }
 
-func (cc *ClustersCache) setExpiration(clusterName string) {
-	if cluster, ok := cc.clusters.Get(clusterName); ok {
+func (cc *ClustersCache) setExpiration(clusterName string, ingressName string, ingressNamespace string) {
+	key := key(clusterName, ingressName, ingressNamespace)
+	if cluster, ok := cc.clusters.Get(key); ok {
 		cc.clusters.Set(clusterName, cluster, clusterExpiration)
 	}
 }
@@ -64,6 +66,8 @@ func (cc *ClustersCache) list() []envoycache.Resource {
 	return res
 }
 
-func key(serviceWithRevisionName string, path string, namespace string) string {
-	return strings.Join([]string{namespace, serviceWithRevisionName, path}, ":")
+// Using only the cluster name is not enough to ensure uniqueness, that's why we
+// use also the ingress info.
+func key(clusterName, ingressName, ingressNamespace string) string {
+	return strings.Join([]string{clusterName, ingressName, ingressNamespace}, ":")
 }

--- a/pkg/generator/cluster_cache_test.go
+++ b/pkg/generator/cluster_cache_test.go
@@ -19,7 +19,7 @@ var testCluster2 = envoy_api_v2.Cluster{
 
 func TestSetCluster(t *testing.T) {
 	cache := newClustersCache()
-	cache.set("helloworld", "/", "test_namespace", &testCluster1)
+	cache.set(&testCluster1, "some_ingress_name", "some_ingress_namespace")
 
 	list := cache.list()
 
@@ -29,8 +29,8 @@ func TestSetCluster(t *testing.T) {
 
 func TestSetSeveralClusters(t *testing.T) {
 	cache := newClustersCache()
-	cache.set("helloworld_1", "/", "test_namespace", &testCluster1)
-	cache.set("helloworld_2", "/", "test_namespace", &testCluster2)
+	cache.set(&testCluster1, "some_ingress_name", "some_ingress_namespace")
+	cache.set(&testCluster2, "some_ingress_name", "some_ingress_namespace")
 
 	list := cache.list()
 	var names []string
@@ -47,21 +47,10 @@ func TestSetSeveralClusters(t *testing.T) {
 	assert.DeepEqual(t, expectedNames, names)
 }
 
-func TestSetExistingClusterReplacesIt(t *testing.T) {
-	cache := newClustersCache()
-	cache.set("helloworld", "/", "test_namespace", &testCluster1)
-	cache.set("helloworld", "/", "test_namespace", &testCluster2) // should replace
-
-	list := cache.list()
-
-	assert.Equal(t, 1, len(list))
-	assert.Equal(t, testCluster2.Name, list[0].(*envoy_api_v2.Cluster).Name)
-}
-
 func TestClustersExpire(t *testing.T) {
 	cleanupInterval := time.Second
 	cache := newClustersCacheWithExpAndCleanupIntervals(time.Second, cleanupInterval)
-	cache.set("helloworld", "/", "test_namespace", &testCluster1)
+	cache.setExpiration(testCluster1.Name, "some_ingress_name", "some_ingress_namespace")
 	time.Sleep(cleanupInterval + time.Second)
 
 	list := cache.list()

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -129,7 +129,7 @@ func addIngressToCaches(caches *Caches,
 				connectTimeout := 5 * time.Second
 				cluster := envoy.NewCluster(split.ServiceName+path, connectTimeout, publicLbEndpoints, http2)
 
-				caches.AddCluster(&cluster, split.ServiceName, split.ServiceNamespace, path)
+				caches.AddCluster(&cluster, ingress.Name, ingress.Namespace)
 
 				weightedCluster := envoy.NewWeightedCluster(split.ServiceName+path, uint32(split.Percent), headersSplit)
 


### PR DESCRIPTION
Makes some changes in the cluster cache to allow setting expirations when deleting an ingress.