### PR TITLE
Expose an stats endpoint at port 9000

### DIFF
--- a/conf/envoy-bootstrap.yaml
+++ b/conf/envoy-bootstrap.yaml
@@ -12,14 +12,54 @@ node:
   cluster: kourier-knative
   id: 3scale-kourier-gateway
 static_resources:
+  listeners:
+    - name: stats_listener
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 9000
+      filter_chains:
+        - filters:
+          - name: envoy.http_connection_manager
+            config:
+              stat_prefix: stats_server
+              route_config:
+                virtual_hosts:
+                  - name: admin_interface
+                    domains:
+                      - "*"
+                    routes:
+                      - match:
+                          safe_regex:
+                            google_re2: {}
+                            regex: '/(certs|stats(/prometheus)?|server_info|clusters|listeners|ready)?'
+                          headers:
+                            - name: ':method'
+                              exact_match: GET
+                        route:
+                          cluster: service_stats
+              http_filters:
+                - name: envoy.router
+                  config: {}
   clusters:
-    - connect_timeout: 1s
+    - name: service_stats
+      connect_timeout: 0.250s
+      type: static
+      load_assignment:
+        cluster_name: service_stats
+        endpoints:
+          lb_endpoints:
+            endpoint:
+              address:
+                pipe:
+                  path: /tmp/envoy.admin
+    - name: xds_cluster
+      connect_timeout: 1s
       hosts:
         - socket_address:
             address: "kourier-control"
             port_value: 18000
       http2_protocol_options: {}
-      name: xds_cluster
       type: STRICT_DNS
 admin:
   access_log_path: "/dev/stdout"

--- a/conf/envoy-bootstrap.yaml
+++ b/conf/envoy-bootstrap.yaml
@@ -1,11 +1,3 @@
-# Base config for an ADS management server on 18000, admin port on 19000
-# From https://github.com/envoyproxy/go-control-plane/blob/master/sample/bootstrap-ads.yaml
-admin:
-  access_log_path: /tmp/test
-  address:
-    socket_address:
-      address: 0.0.0.0
-      port_value: 19000
 dynamic_resources:
   ads_config:
     api_type: GRPC
@@ -29,3 +21,8 @@ static_resources:
       http2_protocol_options: {}
       name: xds_cluster
       type: STRICT_DNS
+admin:
+  access_log_path: "/dev/stdout"
+  address:
+    pipe:
+      path: /tmp/envoy.admin

--- a/deploy/knative_e2e_tests/kourier-istio-system.yaml
+++ b/deploy/knative_e2e_tests/kourier-istio-system.yaml
@@ -221,12 +221,6 @@ metadata:
   namespace: istio-system
 data:
   envoy-bootstrap.yaml: |
-    admin:
-      access_log_path: /tmp/test
-      address:
-        socket_address:
-          address: 0.0.0.0
-          port_value: 19000
     dynamic_resources:
       ads_config:
         api_type: GRPC
@@ -241,23 +235,60 @@ data:
       cluster: kourier-knative
       id: 3scale-kourier-gateway
     static_resources:
+      listeners:
+        - name: stats_listener
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 9000
+          filter_chains:
+            - filters:
+                - name: envoy.http_connection_manager
+                  config:
+                    stat_prefix: stats_server
+                    route_config:
+                      virtual_hosts:
+                        - name: admin_interface
+                          domains:
+                            - "*"
+                          routes:
+                            - match:
+                                safe_regex:
+                                  google_re2: {}
+                                  regex: '/(certs|stats(/prometheus)?|server_info|clusters|listeners|ready)?'
+                                headers:
+                                  - name: ':method'
+                                    exact_match: GET
+                              route:
+                                cluster: service_stats
+                    http_filters:
+                      - name: envoy.router
+                        config: {}
       clusters:
-        - connect_timeout: 0.2s
+        - name: service_stats
+          connect_timeout: 0.250s
+          type: static
           load_assignment:
-            cluster_name: xds_cluster
+            cluster_name: service_stats
             endpoints:
-              - lb_endpoints:
-                - endpoint:
-                    address:
-                      socket_address:
-                        address: kourier-control
-                        port_value: 18000
+              lb_endpoints:
+                endpoint:
+                  address:
+                    pipe:
+                      path: /tmp/envoy.admin
+        - name: xds_cluster
+          connect_timeout: 1s
+          hosts:
+            - socket_address:
+                address: "kourier-control"
+                port_value: 18000
           http2_protocol_options: {}
-          upstream_connection_options:
-            tcp_keepalive: {}
-          lb_policy: ROUND_ROBIN
-          name: xds_cluster
           type: STRICT_DNS
+    admin:
+      access_log_path: "/dev/stdout"
+      address:
+        pipe:
+          path: /tmp/envoy.admin
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -200,12 +200,6 @@ metadata:
   namespace: knative-serving
 data:
   envoy-bootstrap.yaml: |
-    admin:
-      access_log_path: /tmp/test
-      address:
-        socket_address:
-          address: 0.0.0.0
-          port_value: 19000
     dynamic_resources:
       ads_config:
         api_type: GRPC
@@ -220,20 +214,57 @@ data:
       cluster: kourier-knative
       id: 3scale-kourier-gateway
     static_resources:
+      listeners:
+        - name: stats_listener
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 9000
+          filter_chains:
+            - filters:
+                - name: envoy.http_connection_manager
+                  config:
+                    stat_prefix: stats_server
+                    route_config:
+                      virtual_hosts:
+                        - name: admin_interface
+                          domains:
+                            - "*"
+                          routes:
+                            - match:
+                                safe_regex:
+                                  google_re2: {}
+                                  regex: '/(certs|stats(/prometheus)?|server_info|clusters|listeners|ready)?'
+                                headers:
+                                  - name: ':method'
+                                    exact_match: GET
+                              route:
+                                cluster: service_stats
+                    http_filters:
+                      - name: envoy.router
+                        config: {}
       clusters:
-        - connect_timeout: 0.2s
+        - name: service_stats
+          connect_timeout: 0.250s
+          type: static
           load_assignment:
-            cluster_name: xds_cluster
+            cluster_name: service_stats
             endpoints:
-              - lb_endpoints:
-                - endpoint:
-                    address:
-                      socket_address:
-                        address: kourier-control
-                        port_value: 18000
+              lb_endpoints:
+                endpoint:
+                  address:
+                    pipe:
+                      path: /tmp/envoy.admin
+        - name: xds_cluster
+          connect_timeout: 1s
+          hosts:
+            - socket_address:
+                address: "kourier-control"
+                port_value: 18000
           http2_protocol_options: {}
-          upstream_connection_options:
-            tcp_keepalive: {}
-          lb_policy: ROUND_ROBIN
-          name: xds_cluster
           type: STRICT_DNS
+    admin:
+      access_log_path: "/dev/stdout"
+      address:
+        pipe:
+          path: /tmp/envoy.admin


### PR DESCRIPTION
* Envoy admin now listens to an internal UNIX socket.
* Exposes the envoy socket through a listener that only allows "safe" commands