### PR TITLE
Avoid exposing structs unnecessarily

### DIFF
--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -27,11 +27,11 @@ type EnvoyXdsServer struct {
 	snapshotCache  cache.SnapshotCache
 }
 
-// Hasher returns node ID as an ID
-type Hasher struct {
+// hasher returns node ID as an ID
+type hasher struct {
 }
 
-func (h Hasher) ID(node *core.Node) string {
+func (h hasher) ID(node *core.Node) string {
 	if node == nil {
 		return "unknown"
 	}
@@ -40,7 +40,7 @@ func (h Hasher) ID(node *core.Node) string {
 
 func NewEnvoyXdsServer(gatewayPort uint, managementPort uint) EnvoyXdsServer {
 	ctx := context.Background()
-	snapshotCache := cache.NewSnapshotCache(true, Hasher{}, nil)
+	snapshotCache := cache.NewSnapshotCache(true, hasher{}, nil)
 	srv := xds.NewServer(ctx, snapshotCache, nil)
 
 	return EnvoyXdsServer{

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -57,8 +57,8 @@ const (
 
 var dialContext = (&net.Dialer{}).DialContext
 
-// IngressState represents the probing progress at the Ingress scope
-type IngressState struct {
+// ingressState represents the probing progress at the Ingress scope
+type ingressState struct {
 	id      string
 	ingress *v1alpha1.Ingress
 	// pendingCount is the number of pods that haven't been successfully probed yet
@@ -77,7 +77,7 @@ type podState struct {
 }
 
 type workItem struct {
-	ingressState *IngressState
+	ingressState *ingressState
 	podState     *podState
 	url          string
 	podIP        string
@@ -91,7 +91,7 @@ type StatusProber struct {
 
 	// mu guards snapshotStates and podStates
 	mu            sync.Mutex
-	ingressStates map[string]*IngressState
+	ingressStates map[string]*ingressState
 	podStates     map[string]*podState
 
 	workQueue workqueue.RateLimitingInterface
@@ -110,7 +110,7 @@ func NewStatusProber(
 	readyCallback func(ingress *v1alpha1.Ingress)) *StatusProber {
 	return &StatusProber{
 		logger:        logger,
-		ingressStates: make(map[string]*IngressState),
+		ingressStates: make(map[string]*ingressState),
 		podStates:     make(map[string]*podState),
 		workQueue: workqueue.NewNamedRateLimitingQueue(
 			workqueue.DefaultControllerRateLimiter(),
@@ -156,7 +156,7 @@ func (m *StatusProber) IsReady(ingress *v1alpha1.Ingress) (bool, error) {
 	}
 
 	ingCtx, cancel := context.WithCancel(context.Background())
-	snapshotState := &IngressState{
+	snapshotState := &ingressState{
 		id:           ingressKey,
 		ingress:      ingress,
 		pendingCount: 0,
@@ -351,7 +351,7 @@ func (m *StatusProber) processWorkItem() bool {
 	return true
 }
 
-func (m *StatusProber) updateStates(ingressState *IngressState, podState *podState) {
+func (m *StatusProber) updateStates(ingressState *ingressState, podState *podState) {
 	if atomic.AddInt32(&podState.successCount, 1) == 1 {
 		// This is the first successful probe call for the pod, cancel all other work items for this pod
 		podState.cancel()


### PR DESCRIPTION
Makes some structs In the envoy and status packages private.
I've left the generator package for later because I think we might need to split it.