### PR TITLE
Use LoadBalancer instead of ClusterIP for kourier-external

### DIFF
--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -182,7 +182,7 @@ spec:
       targetPort: 8080
   selector:
     app: 3scale-kourier-gateway
-  type: ClusterIP
+  type: LoadBalancer
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
As per title, this patch replaces ClusterIP with LoadBalancer for kourier-external service.

Current configuration does not pass e2e by default. Please refer to  https://github.com/knative/serving/pull/6450.