### PR TITLE
Define just one external service

### DIFF
--- a/deploy/knative_e2e_tests/kourier-istio-system.yaml
+++ b/deploy/knative_e2e_tests/kourier-istio-system.yaml
@@ -188,21 +188,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: kourier-external
-  namespace: istio-system
-spec:
-  ports:
-    - name: http2
-      port: 80
-      protocol: TCP
-      targetPort: 8080
-  selector:
-    app: 3scale-kourier-gateway
-  type: ClusterIP
----
-apiVersion: v1
-kind: Service
-metadata:
   name: kourier-control
   namespace: istio-system
 spec:

--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: knative-serving
 spec:
   ports:
-    - name: http
+    - name: http2
       port: 80
       protocol: TCP
       targetPort: 8080
@@ -168,21 +168,6 @@ spec:
   selector:
     app: 3scale-kourier-gateway
   type: ClusterIP
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kourier-external
-  namespace: knative-serving
-spec:
-  ports:
-    - name: http2
-      port: 80
-      protocol: TCP
-      targetPort: 8080
-  selector:
-    app: 3scale-kourier-gateway
-  type: LoadBalancer
 ---
 apiVersion: v1
 kind: Service

--- a/docs/knative_e2e_tests.md
+++ b/docs/knative_e2e_tests.md
@@ -32,7 +32,7 @@ kubectl patch deployment 3scale-kourier-control -n istio-system --patch "{\"spec
 - Clean-up some things that are not needed:
 ```bash
 kubectl delete deployment 3scale-kourier-control 3scale-kourier-gateway -n knative-serving
-kubectl delete service kourier kourier-control kourier-external kourier-internal -n knative-serving
+kubectl delete service kourier kourier-control kourier-internal -n knative-serving
 ```
 
 - Port-forward Kourier. Make sure you do not have anything else on these ports,

--- a/pkg/knative/ingress.go
+++ b/pkg/knative/ingress.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
+	// These 2 are defined in the deployment yaml
 	internalServiceName = "kourier-internal"
-	externalServiceName = "kourier-external"
+	externalServiceName = "kourier"
 )
 
 func MarkIngressReady(knativeClient versioned.Interface, ingress *networkingv1alpha1.Ingress) error {


### PR DESCRIPTION
Simplifies a bit the deployment. The "kourier" and "kourier-external" services are equivalent. Defining just one is enough.