### PR TITLE
Update ingress status when status field is updated or not ready

### DIFF
--- a/pkg/knative/ingress.go
+++ b/pkg/knative/ingress.go
@@ -17,7 +17,7 @@ func MarkIngressReady(knativeClient versioned.Interface, ingress *networkingv1al
 	//  but that is not exactly true, it can take a while until envoy exposes the routes. Is there a way to get a "callback" from envoy?
 	var err error
 	status := ingress.GetStatus()
-	if ingress.GetGeneration() != status.ObservedGeneration || !ingress.GetStatus().IsReady() {
+	if ingress.GetGeneration() != status.ObservedGeneration || !status.IsReady() {
 		internalDomain := domainForServiceName(internalServiceName)
 		externalDomain := domainForServiceName(externalServiceName)
 

--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -137,22 +137,25 @@ func (m *StatusProber) IsReady(ingress *v1alpha1.Ingress) (bool, error) {
 
 	ingressKey := fmt.Sprintf("%x", hash)
 
-	if ready, ok := func() (bool, bool) {
-		m.mu.Lock()
-		defer m.mu.Unlock()
-		if state, ok := m.ingressStates[ingressKey]; ok {
-			if state.id == ingressKey {
-				state.lastAccessed = time.Now()
-				return atomic.LoadInt32(&state.pendingCount) == 0, true
-			}
+	status := ingress.GetStatus()
+	if ingress.GetGeneration() == status.ObservedGeneration || status.IsReady() {
+		if ready, ok := func() (bool, bool) {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			if state, ok := m.ingressStates[ingressKey]; ok {
+				if state.id == ingressKey {
+					state.lastAccessed = time.Now()
+					return atomic.LoadInt32(&state.pendingCount) == 0, true
+				}
 
-			// Cancel the polling for the outdated version
-			state.cancel()
-			delete(m.ingressStates, ingressKey)
+				// Cancel the polling for the outdated version
+				state.cancel()
+				delete(m.ingressStates, ingressKey)
+			}
+			return false, false
+		}(); ok {
+			return ready, nil
 		}
-		return false, false
-	}(); ok {
-		return ready, nil
 	}
 
 	ingCtx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
This patch adds a condition to update ingress status when status field is updated or not ready.

Currently the ingress is not reconciled when it is deleted.

Fixes https://github.com/3scale/kourier/issues/164