### PR TITLE
Change kourier namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ kubectl apply -f ./samples/helloworld-go.yaml
 - (OPTIONAL) For testing purposes, you can use port-forwarding to make requests to Kourier
 from your machine:
 ```bash
-kubectl port-forward --namespace knative-serving $(kubectl get pod -n knative-serving -l "app=3scale-kourier-gateway" --output=jsonpath="{.items[0].metadata.name}") 8080:8080 19000:19000 8443:8443
+kubectl port-forward --namespace kourier-system $(kubectl get pod -n kourier-system -l "app=3scale-kourier-gateway" --output=jsonpath="{.items[0].metadata.name}") 8080:8080 19000:19000 8443:8443
 
 curl -v -H "Host: helloworld-go.default.127.0.0.1.nip.io" http://localhost:8080 
 ```

--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -1,8 +1,13 @@
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: kourier-system
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: kourier
-  namespace: knative-serving
+  namespace: kourier-system
 spec:
   ports:
     - name: http2
@@ -17,7 +22,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: 3scale-kourier-gateway
-  namespace: knative-serving
+  namespace: kourier-system
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
@@ -75,7 +80,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: 3scale-kourier-control
-  namespace: knative-serving
+  namespace: kourier-system
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
@@ -120,7 +125,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: 3scale-kourier
-  namespace: knative-serving
+  namespace: kourier-system
 rules:
   - apiGroups: [""]
     resources: ["pods", "endpoints", "namespaces", "services", "secrets", "configmaps"]
@@ -139,7 +144,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: 3scale-kourier
-  namespace: knative-serving
+  namespace: kourier-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -152,13 +157,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: 3scale-kourier
-    namespace: knative-serving
+    namespace: kourier-system
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: kourier-internal
-  namespace: knative-serving
+  namespace: kourier-system
 spec:
   ports:
     - name: http2
@@ -173,7 +178,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kourier-control
-  namespace: knative-serving
+  namespace: kourier-system
 spec:
   ports:
     - port: 18000
@@ -187,7 +192,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kourier-bootstrap
-  namespace: knative-serving
+  namespace: kourier-system
 data:
   envoy-bootstrap.yaml: |
     dynamic_resources:

--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -4,6 +4,18 @@ metadata:
   name: kourier-system
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: kourier-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: kourier-system
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: kourier

--- a/docs/knative_e2e_tests.md
+++ b/docs/knative_e2e_tests.md
@@ -16,7 +16,7 @@ make local-setup
 - We need to export a couple of envs to indicate that we are using Kourier as the ingress:
 ```bash
 export GATEWAY_OVERRIDE=kourier
-export GATEWAY_NAMESPACE_OVERRIDE=knative-serving
+export GATEWAY_NAMESPACE_OVERRIDE=kourier-system
 ```
 
 ## Run the Knative tests

--- a/utils/setup-circleci.sh
+++ b/utils/setup-circleci.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+KOURIER_NAMESPACE=knative-serving
+KNATIVE_NAMESPACE=knative-serving
+
 if ! command -v microk8s.kubectl >/dev/null; then
   echo "You need to install microk8s"
   exit 1
@@ -36,13 +39,13 @@ microk8s.enable dns
 
 # Deploys kourier and patches it.
 microk8s.kubectl apply -f deploy/kourier-knative.yaml
-microk8s.kubectl patch deployment 3scale-kourier-control -n knative-serving --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier-control\",\"image\": \"3scale-kourier:$tag\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
-microk8s.kubectl patch deployment 3scale-kourier-gateway -n knative-serving --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier-gateway\",\"image\": \"3scale-kourier-gateway:$tag\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
-microk8s.kubectl patch configmap/config-domain -n knative-serving --type merge -p '{"data":{"127.0.0.1.nip.io":""}}'
-microk8s.kubectl patch configmap/config-network -n knative-serving --type merge -p '{"data":{"clusteringress.class":"kourier.ingress.networking.knative.dev","ingress.class":"kourier.ingress.networking.knative.dev"}}'
+microk8s.kubectl patch deployment 3scale-kourier-control -n ${KOURIER_NAMESPACE} --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier-control\",\"image\": \"3scale-kourier:$tag\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
+microk8s.kubectl patch deployment 3scale-kourier-gateway -n ${KOURIER_NAMESPACE} --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier-gateway\",\"image\": \"3scale-kourier-gateway:$tag\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
+microk8s.kubectl patch configmap/config-domain -n ${KNATIVE_NAMESPACE} --type merge -p '{"data":{"127.0.0.1.nip.io":""}}'
+microk8s.kubectl patch configmap/config-network -n ${KNATIVE_NAMESPACE} --type merge -p '{"data":{"clusteringress.class":"kourier.ingress.networking.knative.dev","ingress.class":"kourier.ingress.networking.knative.dev"}}'
 
 retries=0
-while [[ $(microk8s.kubectl get pods -n knative-serving -l app=3scale-kourier-control -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+while [[ $(microk8s.kubectl get pods -n ${KOURIER_NAMESPACE} -l app=3scale-kourier-control -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
   echo "Waiting for kourier control pod to be ready "
   sleep 10
   if [ $retries -ge 7 ]; then
@@ -53,7 +56,7 @@ while [[ $(microk8s.kubectl get pods -n knative-serving -l app=3scale-kourier-co
 done
 
 retries=0
-while [[ $(microk8s.kubectl get pods -n knative-serving -l app=3scale-kourier-gateway -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+while [[ $(microk8s.kubectl get pods -n ${KOURIER_NAMESPACE} -l app=3scale-kourier-gateway -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
   echo "Waiting for kourier gateway pod to be ready "
   sleep 10
   if [ $retries -ge 7 ]; then
@@ -63,4 +66,4 @@ while [[ $(microk8s.kubectl get pods -n knative-serving -l app=3scale-kourier-ga
   retries=$((retries + 1))
 done
 
-microk8s.kubectl port-forward --namespace knative-serving "$(microk8s.kubectl get pod -n knative-serving -l "app=3scale-kourier-gateway" --output=jsonpath="{.items[0].metadata.name}")" 8080:8080 19000:19000 &>/dev/null &
+microk8s.kubectl port-forward --namespace ${KOURIER_NAMESPACE} "$(microk8s.kubectl get pod -n ${KOURIER_NAMESPACE} -l "app=3scale-kourier-gateway" --output=jsonpath="{.items[0].metadata.name}")" 8080:8080 19000:19000 &>/dev/null &

--- a/utils/setup-circleci.sh
+++ b/utils/setup-circleci.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-KOURIER_NAMESPACE=knative-serving
+KOURIER_NAMESPACE=kourier-system
 KNATIVE_NAMESPACE=knative-serving
 
 if ! command -v microk8s.kubectl >/dev/null; then

--- a/utils/setup.sh
+++ b/utils/setup.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-KOURIER_NAMESPACE=knative-serving
+KOURIER_NAMESPACE=kourier-system
 KNATIVE_NAMESPACE=knative-serving
 
 if ! command -v k3d >/dev/null; then

--- a/utils/setup.sh
+++ b/utils/setup.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+KOURIER_NAMESPACE=knative-serving
+KNATIVE_NAMESPACE=knative-serving
+
 if ! command -v k3d >/dev/null; then
   echo "k3d binary not in path, install with: curl -s https://raw.githubusercontent.com/rancher/k3d/master/install.sh | bash"
   exit 1
@@ -31,13 +34,13 @@ KNATIVE_VERSION=v0.10.0
 kubectl apply -f https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-crds.yaml
 kubectl apply -f https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-core.yaml
 kubectl apply -f deploy/kourier-knative.yaml
-kubectl patch deployment 3scale-kourier-control -n knative-serving --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier-control\",\"image\": \"3scale-kourier:$tag\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
-kubectl patch deployment 3scale-kourier-gateway -n knative-serving --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier-gateway\",\"image\": \"3scale-kourier-gateway:$tag\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
-kubectl patch configmap/config-domain -n knative-serving --type merge -p '{"data":{"127.0.0.1.nip.io":""}}'
-kubectl patch configmap/config-network -n knative-serving --type merge -p '{"data":{"clusteringress.class":"kourier.ingress.networking.knative.dev","ingress.class":"kourier.ingress.networking.knative.dev"}}'
+kubectl patch deployment 3scale-kourier-control -n ${KOURIER_NAMESPACE} --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier-control\",\"image\": \"3scale-kourier:$tag\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
+kubectl patch deployment 3scale-kourier-gateway -n ${KOURIER_NAMESPACE} --patch "{\"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"kourier-gateway\",\"image\": \"3scale-kourier-gateway:$tag\",\"imagePullPolicy\": \"IfNotPresent\"}]}}}}"
+kubectl patch configmap/config-domain -n ${KNATIVE_NAMESPACE} --type merge -p '{"data":{"127.0.0.1.nip.io":""}}'
+kubectl patch configmap/config-network -n ${KNATIVE_NAMESPACE} --type merge -p '{"data":{"clusteringress.class":"kourier.ingress.networking.knative.dev","ingress.class":"kourier.ingress.networking.knative.dev"}}'
 
 retries=0
-while [[ $(kubectl get pods -n knative-serving -l app=3scale-kourier-control -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+while [[ $(kubectl get pods -n ${KOURIER_NAMESPACE} -l app=3scale-kourier-control -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
   echo "Waiting for kourier control pod to be ready "
   sleep 10
   if [ $retries -ge 7 ]; then
@@ -48,7 +51,7 @@ while [[ $(kubectl get pods -n knative-serving -l app=3scale-kourier-control -o 
 done
 
 retries=0
-while [[ $(kubectl get pods -n knative-serving -l app=3scale-kourier-gateway -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+while [[ $(kubectl get pods -n ${KOURIER_NAMESPACE} -l app=3scale-kourier-gateway -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
   echo "Waiting for kourier gateway pod to be ready "
   sleep 10
   if [ $retries -ge 7 ]; then
@@ -59,4 +62,4 @@ while [[ $(kubectl get pods -n knative-serving -l app=3scale-kourier-gateway -o 
 done
 
 # shellcheck disable=SC2046
-kubectl port-forward --namespace knative-serving "$(kubectl get pod -n knative-serving -l "app=3scale-kourier-gateway" --output=jsonpath="{.items[0].metadata.name}")" 8080:8080 8081:8081 19000:19000 8443:8443 &>/dev/null &
+kubectl port-forward --namespace ${KOURIER_NAMESPACE} "$(kubectl get pod -n ${KOURIER_NAMESPACE} -l "app=3scale-kourier-gateway" --output=jsonpath="{.items[0].metadata.name}")" 8080:8080 8081:8081 19000:19000 8443:8443 &>/dev/null &


### PR DESCRIPTION
This changes the kourier namespace to `kourier-system`. Until now it was using the same as knative (`knative-serving`). There's no reason to do that. Also, with this PR we'll no longer need to patch the deployment yaml in Knative (https://github.com/knative/serving/blob/25658ef8c7b1bee4e0996566833e2ced22cdef9b/third_party/kourier-latest/download-kourier.sh#L46).