### PR TITLE
Set headers instead of appending them

### DIFF
--- a/pkg/envoy/headers.go
+++ b/pkg/envoy/headers.go
@@ -15,7 +15,9 @@ func headersToAdd(headers map[string]string) []*core.HeaderValueOption {
 				Value: headerVal,
 			},
 			Append: &wrappers.BoolValue{
-				Value: true,
+				// In Knative Serving, headers are set instead of appended.
+				// Ref: https://github.com/knative/serving/pull/6366
+				Value: false,
 			},
 		}
 


### PR DESCRIPTION
In Knative serving, headers are set instead of appended. See this: https://github.com/knative/serving/pull/6366

This fixes a couple of tests that were failing in the Knative upstream:
- `test/conformance/ingress.TestPostSplitSetHeader`
- `test/conformance/ingress.TestPreSplitSetHeaders`