### PR TITLE
Add support for ingress TLS

### DIFF
--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -30,6 +30,21 @@ spec:
     app: 3scale-kourier-gateway
   type: LoadBalancer
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kourier-tls
+  namespace: kourier-system
+spec:
+  ports:
+    - name: http2
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app: 3scale-kourier-gateway
+  type: LoadBalancer
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/pkg/envoy/listener_test.go
+++ b/pkg/envoy/listener_test.go
@@ -22,7 +22,7 @@ import (
 	is "gotest.tools/assert/cmp"
 )
 
-func TestCreateHTTPListener(t *testing.T) {
+func TestNewHTTPListener(t *testing.T) {
 	manager := NewHttpConnectionManager([]*route.VirtualHost{})
 
 	l, err := NewHTTPListener(&manager, 8080)
@@ -36,7 +36,7 @@ func TestCreateHTTPListener(t *testing.T) {
 	assert.Assert(t, is.Nil(l.FilterChains[0].TransportSocket)) //TLS not configured
 }
 
-func TestCreateHTTPSListener(t *testing.T) {
+func TestNewHTTPSListener(t *testing.T) {
 	manager := NewHttpConnectionManager([]*route.VirtualHost{})
 
 	l, err := NewHTTPSListener(&manager, 8081, "some_certificate_chain", "some_private_key")

--- a/pkg/envoy/listener_test.go
+++ b/pkg/envoy/listener_test.go
@@ -1,7 +1,16 @@
 package envoy
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
+
+	httpconnectionmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+
+	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 
 	"github.com/golang/protobuf/ptypes"
 
@@ -40,16 +49,117 @@ func TestCreateHTTPSListener(t *testing.T) {
 	assert.Equal(t, uint32(8081), l.Address.GetSocketAddress().GetPortValue())
 
 	// Check that TLS is configured
+	certChain, privateKey, err := getTLSCreds(l.FilterChains[0])
+	assert.NilError(t, err)
+	assert.Equal(t, "some_certificate_chain", certChain)
+	assert.Equal(t, "some_private_key", privateKey)
+}
 
-	downstream := &auth.DownstreamTlsContext{}
-
-	err = ptypes.UnmarshalAny(l.FilterChains[0].TransportSocket.GetTypedConfig(), downstream)
-	if err != nil {
-		t.Fatal(err)
+func TestNewHTTPSListenerWithSNI(t *testing.T) {
+	sniMatches := []*SNIMatch{
+		{
+			hosts:            []string{"some_host.com"},
+			certificateChain: "cert1",
+			privateKey:       "key1",
+		},
+		{
+			hosts:            []string{"another_host.com"},
+			certificateChain: "cert2",
+			privateKey:       "key2",
+		},
 	}
 
-	certs := downstream.CommonTlsContext.TlsCertificates[0]
-	assert.Equal(t, "some_certificate_chain", string(certs.CertificateChain.GetInlineBytes()))
-	assert.Equal(t, "some_private_key", string(certs.PrivateKey.GetInlineBytes()))
+	vHost1 := NewVirtualHost(
+		"vHost1", []string{"some_host.com", "some_host.com:*"}, []*route.Route{},
+	)
+	vHost2 := NewVirtualHost(
+		"vHost2", []string{"another_host.com", "another_host.com:*"}, []*route.Route{},
+	)
 
+	manager := NewHttpConnectionManager([]*route.VirtualHost{&vHost1, &vHost2})
+
+	listener, err := NewHTTPSListenerWithSNI(&manager, 8443, sniMatches)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, core.SocketAddress_TCP, listener.Address.GetSocketAddress().Protocol)
+	assert.Equal(t, "0.0.0.0", listener.Address.GetSocketAddress().Address)
+	assert.Equal(t, uint32(8443), listener.Address.GetSocketAddress().GetPortValue())
+
+	// Listener Filter required for SNI
+	assert.Equal(t, listener.ListenerFilters[0].Name, wellknown.TlsInspector)
+
+	assertListenerHasSNIMatchConfigured(
+		t, listener, sniMatches[0], []string{"some_host.com", "some_host.com:*"},
+	)
+
+	assertListenerHasSNIMatchConfigured(
+		t, listener, sniMatches[1], []string{"another_host.com", "another_host.com:*"},
+	)
+}
+
+func assertListenerHasSNIMatchConfigured(t *testing.T, listener *envoy_api_v2.Listener, match *SNIMatch, expectedVHostDomains []string) {
+	filterChainFirstSNIMatch := getFilterChainByServerName(listener, match.hosts)
+	assert.Assert(t, filterChainFirstSNIMatch != nil)
+
+	certChain, privateKey, err := getTLSCreds(filterChainFirstSNIMatch)
+	assert.NilError(t, err)
+	assert.Equal(t, match.certificateChain, certChain)
+	assert.Equal(t, match.privateKey, privateKey)
+
+	vHostsDomains, err := getVHostDomains(filterChainFirstSNIMatch)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, expectedVHostDomains, vHostsDomains)
+}
+
+func getFilterChainByServerName(listener *envoy_api_v2.Listener, serverNames []string) *envoy_api_v2_listener.FilterChain {
+	for _, filterChain := range listener.FilterChains {
+		filterChainMatch := filterChain.GetFilterChainMatch()
+
+		if filterChainMatch != nil && reflect.DeepEqual(filterChainMatch.ServerNames, serverNames) {
+			return filterChain
+		}
+	}
+
+	return nil
+}
+
+// Note: Returns an error when there are multiple certificates
+func getTLSCreds(filterChain *envoy_api_v2_listener.FilterChain) (certChain string, privateKey string, err error) {
+	downstreamTLSContext := &auth.DownstreamTlsContext{}
+	err = ptypes.UnmarshalAny(
+		filterChain.GetTransportSocket().GetTypedConfig(), downstreamTLSContext,
+	)
+	if err != nil {
+		return "", "", err
+	}
+
+	if len(downstreamTLSContext.CommonTlsContext.TlsCertificates) > 1 {
+		return "", "", fmt.Errorf("more than one certificate configured")
+	}
+
+	certs := downstreamTLSContext.CommonTlsContext.TlsCertificates[0]
+	certChain = string(certs.CertificateChain.GetInlineBytes())
+	privateKey = string(certs.PrivateKey.GetInlineBytes())
+
+	return certChain, privateKey, nil
+}
+
+// Note: Returns an error when there are multiple virtual hosts configured
+func getVHostDomains(filterChain *envoy_api_v2_listener.FilterChain) ([]string, error) {
+	connManager := httpconnectionmanagerv2.HttpConnectionManager{}
+	err := ptypes.UnmarshalAny(filterChain.Filters[0].GetTypedConfig(), &connManager)
+
+	if err != nil {
+		return nil, err
+	}
+
+	routeConfig := connManager.GetRouteSpecifier().(*httpconnectionmanagerv2.HttpConnectionManager_RouteConfig).RouteConfig
+
+	if len(routeConfig.VirtualHosts) > 1 {
+		return nil, fmt.Errorf("more than one virtual host configured")
+	}
+
+	return routeConfig.VirtualHosts[0].Domains, nil
 }

--- a/pkg/generator/caches_test.go
+++ b/pkg/generator/caches_test.go
@@ -156,6 +156,10 @@ func getVHostsNames(listeners []*v2.Listener) ([]string, error) {
 	var res []string
 
 	for _, listener := range listeners {
+		if len(listener.GetFilterChains()) == 0 {
+			continue
+		}
+
 		filterConfig := listener.GetFilterChains()[0].Filters[0].GetTypedConfig()
 		httpConnManager := httpconnmanagerv2.HttpConnectionManager{}
 		err := ptypes.UnmarshalAny(filterConfig, &httpConnManager)


### PR DESCRIPTION
An ingress can have a TLS field. See this example:
https://github.com/knative/serving/blob/83e72f0b1ee0508b2a4ce2c487ba571cffe90dde/test/conformance/ingress/tls_test.go#L59

That's a test from the Knative serving repo that was failing when using Kourier because we were ignoring that field. This PR fixes it.

SNI routing has been implemented as described in the Envoy docs: https://www.envoyproxy.io/docs/envoy/latest/faq/configuration/sni.html