### PR TITLE
Expose http and https in same service

### DIFF
--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -22,22 +22,11 @@ metadata:
   namespace: kourier-system
 spec:
   ports:
-    - name: http2
+    - name: http
       port: 80
       protocol: TCP
       targetPort: 8080
-  selector:
-    app: 3scale-kourier-gateway
-  type: LoadBalancer
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kourier-tls
-  namespace: kourier-system
-spec:
-  ports:
-    - name: http2
+    - name: https
       port: 443
       protocol: TCP
       targetPort: 8443
@@ -75,7 +64,11 @@ spec:
           imagePullPolicy: Always
           name: kourier-gateway
           ports:
-            - containerPort: 8080
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: https
+              containerPort: 8443
               protocol: TCP
           resources: {}
           terminationMessagePath: /dev/termination-log


### PR DESCRIPTION
Without this, the ["TestIngressTLS" test of Knative Serving](https://github.com/knative/serving/blob/83e72f0b1ee0508b2a4ce2c487ba571cffe90dde/test/conformance/ingress/tls_test.go#L31) passes locally, but it fails in the upstream.