### PR TITLE
Delete old TODO that no longer applies

### DIFF
--- a/pkg/knative/ingress.go
+++ b/pkg/knative/ingress.go
@@ -14,8 +14,6 @@ const (
 )
 
 func MarkIngressReady(knativeClient versioned.Interface, ingress *networkingv1alpha1.Ingress) error {
-	// TODO: Improve. Currently once we go trough the generation of the envoy cache, we mark the objects as Ready,
-	//  but that is not exactly true, it can take a while until envoy exposes the routes. Is there a way to get a "callback" from envoy?
 	var err error
 	status := ingress.GetStatus()
 	if ingress.GetGeneration() != status.ObservedGeneration || !status.IsReady() {


### PR DESCRIPTION
The comment no longer applies. What's mentioned there is now handled by the status prober.