### PR TITLE
Fix statusmanager logic for marking ready an ingress

### DIFF
--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -138,7 +138,7 @@ func (m *StatusProber) IsReady(ingress *v1alpha1.Ingress) (bool, error) {
 	ingressKey := fmt.Sprintf("%x", hash)
 
 	status := ingress.GetStatus()
-	if ingress.GetGeneration() == status.ObservedGeneration || status.IsReady() {
+	if ingress.GetGeneration() == status.ObservedGeneration && status.IsReady() {
 		if ready, ok := func() (bool, bool) {
 			m.mu.Lock()
 			defer m.mu.Unlock()


### PR DESCRIPTION
In some situations an ingress can be modified and while it will remain
marked as Ready, the generation and the observer generation will not
match, marking the ksvc as not ready.

This commit solves this situation by fixing a problem in the
statusmanager logic.