### PR TITLE
Refactor: Move helper to instantiate HTTPConnManager with RDS

### DIFF
--- a/pkg/envoy/http_connection_manager.go
+++ b/pkg/envoy/http_connection_manager.go
@@ -2,10 +2,12 @@ package envoy
 
 import (
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
 	envoy_accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/duration"
 
 	httpconnectionmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
@@ -27,6 +29,23 @@ func NewHttpConnectionManager(virtualHosts []*route.VirtualHost) httpconnectionm
 			},
 		},
 		AccessLog: accessLogs(),
+	}
+}
+
+func NewRDSHTTPConnectionManager(routeConfigName string) httpconnectionmanagerv2.HttpConnectionManager_Rds {
+	return httpconnectionmanagerv2.HttpConnectionManager_Rds{
+		Rds: &httpconnectionmanagerv2.Rds{
+			ConfigSource: &envoy_api_v2_core.ConfigSource{
+				ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_Ads{
+					Ads: &envoy_api_v2_core.AggregatedConfigSource{},
+				},
+				InitialFetchTimeout: &duration.Duration{
+					Seconds: 10,
+					Nanos:   0,
+				},
+			},
+			RouteConfigName: routeConfigName,
+		},
 	}
 }
 

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -30,6 +30,8 @@ const (
 	envCertsSecretName      = "CERTS_SECRET_NAME"
 	certFieldInSecret       = "tls.crt"
 	keyFieldInSecret        = "tls.key"
+	externalRouteConfigName = "external_services"
+	internalRouteConfigName = "internal_services"
 )
 
 // For now, when updating the info for an ingress we delete it, and then
@@ -224,8 +226,8 @@ func listenersFromVirtualHosts(externalVirtualHosts []*route.VirtualHost,
 	originalExternalVHosts := externalRouteConfig.VirtualHosts
 
 	// Set proper names so those can be referred later.
-	internalRouteConfig.Name = "internal_services"
-	externalRouteConfig.Name = "external_services"
+	internalRouteConfig.Name = internalRouteConfigName
+	externalRouteConfig.Name = externalRouteConfigName
 
 	// Now we save the RouteConfigs with the proper name and all the virtualhosts etc.. into the cache.
 	caches.routeConfig = []v2.RouteConfiguration{}
@@ -234,11 +236,11 @@ func listenersFromVirtualHosts(externalVirtualHosts []*route.VirtualHost,
 
 	// Now let's forget about the cache, and override the internal manager to point to the RDS and look for the proper
 	// names.
-	internalRDSHTTPConnectionManager := envoy.NewRDSHTTPConnectionManager("internal_services")
+	internalRDSHTTPConnectionManager := envoy.NewRDSHTTPConnectionManager(internalRouteConfigName)
 	internalManager.RouteSpecifier = &internalRDSHTTPConnectionManager
 
 	// Set the discovery to ADS
-	externalRDSHTTPConnectionManager := envoy.NewRDSHTTPConnectionManager("external_services")
+	externalRDSHTTPConnectionManager := envoy.NewRDSHTTPConnectionManager(externalRouteConfigName)
 	externalManager.RouteSpecifier = &externalRDSHTTPConnectionManager
 
 	// CleanUp virtual hosts.


### PR DESCRIPTION
This PR simply moves the code to instantiate an HTTPConnectionManager with RDS to the Envoy package. That code is Envoy specific, so it should be in the envoy package to be consistent with the rest of the codebase.