### PR TITLE
Remove unnecessary pointer conversions and move them to their constructors.

### DIFF
--- a/pkg/envoy/cluster.go
+++ b/pkg/envoy/cluster.go
@@ -9,8 +9,8 @@ import (
 	"github.com/golang/protobuf/ptypes"
 )
 
-func NewCluster(name string, connectTimeout time.Duration, endpoints []*endpoint.LbEndpoint, isHTTP2 bool) v2.Cluster {
-	cluster := v2.Cluster{
+func NewCluster(name string, connectTimeout time.Duration, endpoints []*endpoint.LbEndpoint, isHTTP2 bool) *v2.Cluster {
+	cluster := &v2.Cluster{
 		Name: name,
 		ClusterDiscoveryType: &v2.Cluster_Type{
 			Type: v2.Cluster_STRICT_DNS,

--- a/pkg/envoy/cluster_test.go
+++ b/pkg/envoy/cluster_test.go
@@ -15,7 +15,7 @@ func TestNewCluster(t *testing.T) {
 
 	endpoint1 := NewLBEndpoint("127.0.0.1", 1234)
 	endpoint2 := NewLBEndpoint("127.0.0.2", 1234)
-	endpoints := []*endpoint.LbEndpoint{&endpoint1, &endpoint2}
+	endpoints := []*endpoint.LbEndpoint{endpoint1, endpoint2}
 
 	c := NewCluster(name, connectTimeout, endpoints, true)
 

--- a/pkg/envoy/headers.go
+++ b/pkg/envoy/headers.go
@@ -9,7 +9,7 @@ func headersToAdd(headers map[string]string) []*core.HeaderValueOption {
 	var res []*core.HeaderValueOption
 
 	for headerName, headerVal := range headers {
-		header := core.HeaderValueOption{
+		header := &core.HeaderValueOption{
 			Header: &core.HeaderValue{
 				Key:   headerName,
 				Value: headerVal,
@@ -21,7 +21,7 @@ func headersToAdd(headers map[string]string) []*core.HeaderValueOption {
 			},
 		}
 
-		res = append(res, &header)
+		res = append(res, header)
 
 	}
 

--- a/pkg/envoy/lb_endpoint.go
+++ b/pkg/envoy/lb_endpoint.go
@@ -5,7 +5,7 @@ import (
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 )
 
-func NewLBEndpoint(ip string, port uint32) endpoint.LbEndpoint {
+func NewLBEndpoint(ip string, port uint32) *endpoint.LbEndpoint {
 	serviceEndpoint := &core.Address{
 		Address: &core.Address_SocketAddress{
 			SocketAddress: &core.SocketAddress{
@@ -19,7 +19,7 @@ func NewLBEndpoint(ip string, port uint32) endpoint.LbEndpoint {
 		},
 	}
 
-	return endpoint.LbEndpoint{
+	return &endpoint.LbEndpoint{
 		HostIdentifier: &endpoint.LbEndpoint_Endpoint{
 			Endpoint: &endpoint.Endpoint{
 				Address: serviceEndpoint,

--- a/pkg/envoy/route.go
+++ b/pkg/envoy/route.go
@@ -16,9 +16,9 @@ func NewRoute(name string,
 	routeTimeout time.Duration,
 	retryAttempts uint32,
 	perTryTimeout time.Duration,
-	headers map[string]string) route.Route {
+	headers map[string]string) *route.Route {
 
-	return route.Route{
+	return &route.Route{
 		Name: name,
 		Match: &route.RouteMatch{
 			PathSpecifier: &route.RouteMatch_Prefix{
@@ -43,8 +43,8 @@ func NewRoute(name string,
 }
 
 // Creates a route that simply returns 200
-func NewRouteStatusOK(name string, path string) route.Route {
-	return route.Route{
+func NewRouteStatusOK(name string, path string) *route.Route {
+	return &route.Route{
 		Name: name,
 		Match: &route.RouteMatch{
 			PathSpecifier: &route.RouteMatch_Path{

--- a/pkg/envoy/weighted_cluster.go
+++ b/pkg/envoy/weighted_cluster.go
@@ -5,8 +5,8 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 )
 
-func NewWeightedCluster(name string, trafficPerc uint32, headers map[string]string) route.WeightedCluster_ClusterWeight {
-	return route.WeightedCluster_ClusterWeight{
+func NewWeightedCluster(name string, trafficPerc uint32, headers map[string]string) *route.WeightedCluster_ClusterWeight {
+	return &route.WeightedCluster_ClusterWeight{
 		Name: name,
 		Weight: &wrappers.UInt32Value{
 			Value: trafficPerc,

--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -19,7 +19,7 @@ type VHostsForIngresses map[string][]*route.VirtualHost
 
 type Caches struct {
 	endpoints   []*endpoint.Endpoint
-	clusters    ClustersCache
+	clusters    *ClustersCache
 	routes      []*route.Route
 	routeConfig []v2.RouteConfiguration
 	listeners   []*v2.Listener
@@ -36,8 +36,8 @@ type Caches struct {
 	sniMatchesForIngress           map[string][]*envoy.SNIMatch
 }
 
-func NewCaches() Caches {
-	caches := Caches{
+func NewCaches() *Caches {
+	return &Caches{
 		clusters:                       newClustersCache(),
 		localVirtualHostsForIngress:    make(VHostsForIngresses),
 		externalVirtualHostsForIngress: make(VHostsForIngresses),
@@ -46,8 +46,6 @@ func NewCaches() Caches {
 		clustersToIngress:              make(map[string][]string),
 		sniMatchesForIngress:           make(map[string][]*envoy.SNIMatch),
 	}
-
-	return caches
 }
 
 func (caches *Caches) GetIngress(ingressName, ingressNamespace string) *v1alpha1.Ingress {

--- a/pkg/generator/caches_test.go
+++ b/pkg/generator/caches_test.go
@@ -21,7 +21,7 @@ func TestDeleteIngressInfo(t *testing.T) {
 	firstIngressName := "ingress_1"
 	firstIngressNamespace := "ingress_1_namespace"
 	createTestDataForIngress(
-		&caches,
+		caches,
 		firstIngressName,
 		firstIngressNamespace,
 		"cluster_for_ingress_1",
@@ -35,7 +35,7 @@ func TestDeleteIngressInfo(t *testing.T) {
 	secondIngressName := "ingress_2"
 	secondIngressNamespace := "ingress_2_namespace"
 	createTestDataForIngress(
-		&caches,
+		caches,
 		secondIngressName,
 		secondIngressNamespace,
 		"cluster_for_ingress_2",
@@ -85,7 +85,7 @@ func TestDeleteIngressInfoWhenDoesNotExist(t *testing.T) {
 	firstIngressName := "ingress_1"
 	firstIngressNamespace := "ingress_1_namespace"
 	createTestDataForIngress(
-		&caches,
+		caches,
 		firstIngressName,
 		firstIngressNamespace,
 		"cluster_for_ingress_1",

--- a/pkg/generator/cluster_cache.go
+++ b/pkg/generator/cluster_cache.go
@@ -34,14 +34,14 @@ type ClustersCache struct {
 	clusters *gocache.Cache
 }
 
-func newClustersCache() ClustersCache {
+func newClustersCache() *ClustersCache {
 	goCache := gocache.New(defaultExpiration, defaultCleanupInterval)
-	return ClustersCache{clusters: goCache}
+	return &ClustersCache{clusters: goCache}
 }
 
-func newClustersCacheWithExpAndCleanupIntervals(expiration time.Duration, cleanupInterval time.Duration) ClustersCache {
+func newClustersCacheWithExpAndCleanupIntervals(expiration time.Duration, cleanupInterval time.Duration) *ClustersCache {
 	goCache := gocache.New(expiration, cleanupInterval)
-	return ClustersCache{clusters: goCache}
+	return &ClustersCache{clusters: goCache}
 }
 
 func (cc *ClustersCache) set(cluster *v2.Cluster, ingressName string, ingressNamespace string) {

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -104,7 +104,7 @@ func TestTrafficSplits(t *testing.T) {
 
 	// Check that there is one route in the result
 	if err := UpdateInfoForIngress(
-		&caches,
+		caches,
 		&ingress,
 		kubeClient,
 		newMockedEndpointsLister(),

--- a/pkg/knative/ingress_rule.go
+++ b/pkg/knative/ingress_rule.go
@@ -11,7 +11,7 @@ import (
 // This applies both for internal and external domains.
 // More info https://github.com/envoyproxy/envoy/issues/886
 
-func ExternalDomains(rule *v1alpha1.IngressRule, localDomainName string) []string {
+func ExternalDomains(rule v1alpha1.IngressRule, localDomainName string) []string {
 	var res []string
 
 	for _, host := range rule.Hosts {
@@ -28,7 +28,7 @@ func ExternalDomains(rule *v1alpha1.IngressRule, localDomainName string) []strin
 // 	- sub-route_host.namespace
 // 	- sub-route_host.namespace.svc
 // 	- Each of the previous ones with ":*" appended
-func InternalDomains(rule *v1alpha1.IngressRule, localDomainName string) []string {
+func InternalDomains(rule v1alpha1.IngressRule, localDomainName string) []string {
 	var res []string
 
 	for _, host := range rule.Hosts {
@@ -48,7 +48,7 @@ func InternalDomains(rule *v1alpha1.IngressRule, localDomainName string) []strin
 	return res
 }
 
-func RuleIsExternal(rule *v1alpha1.IngressRule, ingressVisibility v1alpha1.IngressVisibility) bool {
+func RuleIsExternal(rule v1alpha1.IngressRule, ingressVisibility v1alpha1.IngressVisibility) bool {
 	switch rule.Visibility {
 	case v1alpha1.IngressVisibilityExternalIP:
 		return true

--- a/pkg/knative/ingress_rule_test.go
+++ b/pkg/knative/ingress_rule_test.go
@@ -16,7 +16,7 @@ var testRule = v1alpha1.IngressRule{
 }
 
 func TestExternalDomains(t *testing.T) {
-	externalDomains := ExternalDomains(&testRule, "cluster.local")
+	externalDomains := ExternalDomains(testRule, "cluster.local")
 
 	expected := []string{
 		"helloworld-go.default.example.com",
@@ -28,7 +28,7 @@ func TestExternalDomains(t *testing.T) {
 }
 
 func TestInternalDomains(t *testing.T) {
-	internalDomains := InternalDomains(&testRule, "cluster.local")
+	internalDomains := InternalDomains(testRule, "cluster.local")
 
 	expected := []string{
 		"helloworld-go.default",
@@ -51,18 +51,18 @@ func TestRuleIsExternalWithVisibility(t *testing.T) {
 		Visibility: v1alpha1.IngressVisibilityClusterLocal,
 	}
 
-	assert.Equal(t, RuleIsExternal(&externalRule, ""), true)
-	assert.Equal(t, RuleIsExternal(&internalRule, ""), false)
+	assert.Equal(t, RuleIsExternal(externalRule, ""), true)
+	assert.Equal(t, RuleIsExternal(internalRule, ""), false)
 }
 
 func TestRuleIsExternalWithIngressVisibility(t *testing.T) {
 	ruleWithoutVisibility := v1alpha1.IngressRule{Visibility: ""}
 
 	assert.Equal(
-		t, RuleIsExternal(&ruleWithoutVisibility, v1alpha1.IngressVisibilityClusterLocal), false,
+		t, RuleIsExternal(ruleWithoutVisibility, v1alpha1.IngressVisibilityClusterLocal), false,
 	)
 	assert.Equal(
-		t, RuleIsExternal(&ruleWithoutVisibility, v1alpha1.IngressVisibilityExternalIP), true,
+		t, RuleIsExternal(ruleWithoutVisibility, v1alpha1.IngressVisibilityExternalIP), true,
 	)
 }
 
@@ -70,5 +70,5 @@ func TestRuleIsExternalWithoutVisibility(t *testing.T) {
 	ruleWithoutVisibility := v1alpha1.IngressRule{Visibility: ""}
 
 	// Knative defaults to external, so it should return true
-	assert.Equal(t, RuleIsExternal(&ruleWithoutVisibility, ""), true)
+	assert.Equal(t, RuleIsExternal(ruleWithoutVisibility, ""), true)
 }

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -72,7 +72,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		EndpointsLister: endpointsInformer.Lister(),
 		EnvoyXDSServer:  envoyXdsServer,
 		kubeClient:      kubernetesClient,
-		CurrentCaches:   &caches,
+		CurrentCaches:   caches,
 		statusManager:   statusProber,
 	}
 


### PR DESCRIPTION
I hope this disentangles the use of pointer vs. no-pointer a little.

When to use a pointer? For "foreign" objects (like the Envoy stuff) I usually look up their API and see if the functions are defined on the respective pointer receiver. If so, you probably should use pointers in your code for these resources throughout.