### PR TITLE
refactor: extract generation of the status virtual host

### DIFF
--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -101,15 +101,13 @@ func (caches *Caches) AddInternalVirtualHostForIngress(vHost *route.VirtualHost,
 }
 
 func (caches *Caches) AddStatusVirtualHost() {
-
 	var ingresses []*v1alpha1.Ingress
 	for _, val := range caches.ingresses {
 		ingresses = append(ingresses, val)
 	}
 
-	ikrs := internalKourierRoutes(ingresses)
-	ikvh := internalKourierVirtualHost(ikrs)
-	caches.statusVirtualHost = &ikvh
+	statusVirtualHost := statusVHost(ingresses)
+	caches.statusVirtualHost = &statusVirtualHost
 }
 
 func (caches *Caches) AddSNIMatch(sniMatch *envoy.SNIMatch, ingressName string, ingressNamespace string) {
@@ -202,9 +200,8 @@ func (caches *Caches) DeleteIngressInfo(ingressName string, ingressNamespace str
 		ingresses = append(ingresses, val)
 	}
 
-	ikr := internalKourierRoutes(ingresses)
-	ikvh := internalKourierVirtualHost(ikr)
-	newClusterLocalVirtualHosts = append(newClusterLocalVirtualHosts, &ikvh)
+	statusVirtualHost := statusVHost(ingresses)
+	newClusterLocalVirtualHosts = append(newClusterLocalVirtualHosts, &statusVirtualHost)
 
 	// We now need the cache in the listenersFromVirtualHosts.
 	caches.listeners, err = listenersFromVirtualHosts(

--- a/pkg/generator/status_vhost.go
+++ b/pkg/generator/status_vhost.go
@@ -1,0 +1,53 @@
+package generator
+
+import (
+	"fmt"
+	"kourier/pkg/config"
+	"kourier/pkg/envoy"
+
+	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	log "github.com/sirupsen/logrus"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/pkg/reconciler/ingress/resources"
+)
+
+// Generates an internal virtual host that signals that the Envoy instance has
+// been configured for all the ingresses received in the params.
+// The virtual host generated contains a route for each ingress received in the
+// params. The path of the routes are hashed ingresses. With this, if the
+// request for a hashed ingress is successful, we know that the gateway has been
+// configured for that ingress.
+func statusVHost(ingresses []*v1alpha1.Ingress) route.VirtualHost {
+	return envoy.NewVirtualHost(
+		config.InternalKourierDomain,
+		[]string{config.InternalKourierDomain},
+		statusRoutes(ingresses),
+	)
+}
+
+func statusRoutes(ingresses []*v1alpha1.Ingress) []*route.Route {
+	var hashes []string
+	var routes []*route.Route
+	for _, ingress := range ingresses {
+		hash, err := resources.ComputeIngressHash(ingress)
+		if err != nil {
+			log.Errorf("Failed to hash ingress %s: %s", ingress.Name, err)
+			break
+		}
+		hashes = append(hashes, fmt.Sprintf("%x", hash))
+	}
+
+	for _, hash := range hashes {
+		name := fmt.Sprintf("%s_%s", config.InternalKourierDomain, hash)
+		path := fmt.Sprintf("%s/%s", config.InternalKourierPath, hash)
+		routes = append(routes, envoy.NewRouteStatusOK(name, path))
+	}
+
+	staticRoute := envoy.NewRouteStatusOK(
+		config.InternalKourierDomain,
+		config.InternalKourierPath,
+	)
+	routes = append(routes, staticRoute)
+
+	return routes
+}


### PR DESCRIPTION
This PR extracts the generation of the status virtual host into its own file. It's a piece that can be understood and tested in isolation, so I think it's better to have it in a separate file. While at it, I added some documentation.

This is part of a refactor effort to make the generator module easier to understand. More PRs coming in the next days :smile: 