### PR TITLE
Use http2 instead of http as the port names

### DIFF
--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: kourier-system
 spec:
   ports:
-    - name: http
+    - name: http2
       port: 80
       protocol: TCP
       targetPort: 8080
@@ -64,7 +64,7 @@ spec:
           imagePullPolicy: Always
           name: kourier-gateway
           ports:
-            - name: http
+            - name: http2
               containerPort: 8080
               protocol: TCP
             - name: https


### PR DESCRIPTION
related to: https://github.com/openshift-knative/serverless-operator/commit/27a58f4c1800f952effe64d27feaa76e9ae3b2fb