### PR TITLE
Refresh config on cluster eviction

### DIFF
--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -52,6 +52,11 @@ func NewCaches(logger *zap.SugaredLogger) *Caches {
 	}
 }
 
+// SetOnEvicted allows to set a function that will be executed when any key on the cache expires.
+func (caches *Caches) SetOnEvicted(f func(string, interface{})) {
+	caches.clusters.clusters.OnEvicted(f)
+}
+
 func (caches *Caches) GetIngress(ingressName, ingressNamespace string) *v1alpha1.Ingress {
 	caches.logger.Debugf("getting ingress: %s/%s", ingressName, ingressNamespace)
 	return caches.ingresses[mapKey(ingressName, ingressNamespace)]

--- a/pkg/generator/cluster_cache.go
+++ b/pkg/generator/cluster_cache.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	clusterExpiration      = 5 * time.Minute
+	clusterExpiration      = 15 * time.Second
 	defaultExpiration      = gocache.NoExpiration
-	defaultCleanupInterval = 10 * time.Minute
+	defaultCleanupInterval = 1 * time.Minute
 )
 
 type ClustersCache struct {


### PR DESCRIPTION
- Reduce the times for cache expiration and Cleanup.