### PR TITLE
Adds debug logging and named loggers

### DIFF
--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -53,29 +53,29 @@ func NewCaches(logger *zap.SugaredLogger) *Caches {
 }
 
 func (caches *Caches) GetIngress(ingressName, ingressNamespace string) *v1alpha1.Ingress {
-	caches.logger.Debugf("getting ingress: %s/%s\n", ingressName, ingressNamespace)
+	caches.logger.Debugf("getting ingress: %s/%s", ingressName, ingressNamespace)
 	return caches.ingresses[mapKey(ingressName, ingressNamespace)]
 }
 
 func (caches *Caches) AddIngress(ingress *v1alpha1.Ingress) {
-	caches.logger.Debugf("adding ingress: %s/%s\n", ingress.Name, ingress.Namespace)
+	caches.logger.Debugf("adding ingress: %s/%s", ingress.Name, ingress.Namespace)
 	caches.ingresses[mapKey(ingress.Name, ingress.Namespace)] = ingress
 }
 
 func (caches *Caches) DeleteIngress(ingressName, ingressNamespace string) {
-	caches.logger.Debugf("deleting ingress: %s/%s\n", ingressName, ingressNamespace)
+	caches.logger.Debugf("deleting ingress: %s/%s", ingressName, ingressNamespace)
 	delete(caches.ingresses, mapKey(ingressName, ingressNamespace))
 	delete(caches.clustersToIngress, mapKey(ingressName, ingressNamespace))
 }
 
 func (caches *Caches) AddCluster(cluster *v2.Cluster, ingressName string, ingressNamespace string) {
-	caches.logger.Debugf("adding cluster %s for ingress %s/%s\n", cluster.Name, ingressName, ingressNamespace)
+	caches.logger.Debugf("adding cluster %s for ingress %s/%s", cluster.Name, ingressName, ingressNamespace)
 	caches.clusters.set(cluster, ingressName, ingressNamespace)
 	caches.addClustersForIngress(cluster, ingressName, ingressNamespace)
 }
 
 func (caches *Caches) AddRoute(route *route.Route, ingressName string, ingressNamespace string) {
-	caches.logger.Debugf("adding route %s for ingress %s/%s\n", route.Name, ingressName, ingressNamespace)
+	caches.logger.Debugf("adding route %s for ingress %s/%s", route.Name, ingressName, ingressNamespace)
 	caches.routes = append(caches.routes, route)
 
 	key := mapKey(ingressName, ingressNamespace)
@@ -83,7 +83,7 @@ func (caches *Caches) AddRoute(route *route.Route, ingressName string, ingressNa
 }
 
 func (caches *Caches) addClustersForIngress(cluster *v2.Cluster, ingressName string, ingressNamespace string) {
-	caches.logger.Debugf("adding cluster %s for ingress %s/%s\n", cluster.Name, ingressName, ingressNamespace)
+	caches.logger.Debugf("adding cluster %s for ingress %s/%s", cluster.Name, ingressName, ingressNamespace)
 	key := mapKey(ingressName, ingressNamespace)
 
 	caches.clustersToIngress[key] = append(
@@ -93,7 +93,7 @@ func (caches *Caches) addClustersForIngress(cluster *v2.Cluster, ingressName str
 }
 
 func (caches *Caches) AddExternalVirtualHostForIngress(vHost *route.VirtualHost, ingressName string, ingressNamespace string) {
-	caches.logger.Debugf("adding external virtualhost %s for ingress %s/%s\n", vHost.Name, ingressName,
+	caches.logger.Debugf("adding external virtualhost %s for ingress %s/%s", vHost.Name, ingressName,
 		ingressNamespace)
 	key := mapKey(ingressName, ingressNamespace)
 
@@ -104,7 +104,7 @@ func (caches *Caches) AddExternalVirtualHostForIngress(vHost *route.VirtualHost,
 }
 
 func (caches *Caches) AddInternalVirtualHostForIngress(vHost *route.VirtualHost, ingressName string, ingressNamespace string) {
-	caches.logger.Debugf("adding internal virtualhost %s for ingress %s/%s\n", vHost.Name, ingressName,
+	caches.logger.Debugf("adding internal virtualhost %s for ingress %s/%s", vHost.Name, ingressName,
 		ingressNamespace)
 
 	key := mapKey(ingressName, ingressNamespace)
@@ -125,7 +125,7 @@ func (caches *Caches) AddStatusVirtualHost() {
 }
 
 func (caches *Caches) AddSNIMatch(sniMatch *envoy.SNIMatch, ingressName string, ingressNamespace string) {
-	caches.logger.Debugf("adding SNIMatch for ingress %s/%s\n", ingressName, ingressNamespace)
+	caches.logger.Debugf("adding SNIMatch for ingress %s/%s", ingressName, ingressNamespace)
 	key := mapKey(ingressName, ingressNamespace)
 	caches.sniMatchesForIngress[key] = append(caches.sniMatchesForIngress[key], sniMatch)
 }
@@ -151,11 +151,11 @@ func (caches *Caches) SetListeners(kubeclient kubeclient.Interface) error {
 }
 
 func (caches *Caches) ToEnvoySnapshot() (cache.Snapshot, error) {
-	caches.logger.Debugf("Preparing Envoy Snapshot\n")
+	caches.logger.Debugf("Preparing Envoy Snapshot")
 
 	endpoints := make([]cache.Resource, len(caches.endpoints))
 	for i := range caches.endpoints {
-		caches.logger.Debugf("Adding Endpoint %#v\n", caches.endpoints[i])
+		caches.logger.Debugf("Adding Endpoint %#v", caches.endpoints[i])
 		endpoints[i] = caches.endpoints[i]
 	}
 
@@ -167,13 +167,13 @@ func (caches *Caches) ToEnvoySnapshot() (cache.Snapshot, error) {
 		// in the Knative serving test suite fails sometimes.
 		// Ref: https://github.com/knative/serving/blob/f6da03e5dfed78593c4f239c3c7d67c5d7c55267/test/conformance/ingress/update_test.go#L37
 		caches.routeConfig[i].ValidateClusters = &wrappers.BoolValue{Value: true}
-		caches.logger.Debugf("Adding Route %#v\n", &caches.routeConfig[i])
+		caches.logger.Debugf("Adding Route %#v", &caches.routeConfig[i])
 		routes[i] = &caches.routeConfig[i]
 	}
 
 	listeners := make([]cache.Resource, len(caches.listeners))
 	for i := range caches.listeners {
-		caches.logger.Debugf("Adding listener %#v\n", caches.listeners[i])
+		caches.logger.Debugf("Adding listener %#v", caches.listeners[i])
 		listeners[i] = caches.listeners[i]
 	}
 

--- a/pkg/generator/caches_test.go
+++ b/pkg/generator/caches_test.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"testing"
 
+	"go.uber.org/zap"
+
 	"gotest.tools/assert"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -14,7 +16,8 @@ import (
 )
 
 func TestDeleteIngressInfo(t *testing.T) {
-	caches := NewCaches()
+	logger := zap.S()
+	caches := NewCaches(logger)
 	kubeClient := fake.Clientset{}
 
 	// Add info for an ingress
@@ -77,8 +80,9 @@ func TestDeleteIngressInfo(t *testing.T) {
 func TestDeleteIngressInfoWhenDoesNotExist(t *testing.T) {
 	// If the ingress does not exist, nothing should be deleted from the caches
 	// instance.
+	logger := zap.S()
 
-	caches := NewCaches()
+	caches := NewCaches(logger)
 	kubeClient := fake.Clientset{}
 
 	// Add info for an ingress

--- a/pkg/generator/cluster_cache.go
+++ b/pkg/generator/cluster_cache.go
@@ -42,9 +42,10 @@ func newClustersCache(logger *zap.SugaredLogger) *ClustersCache {
 	return &ClustersCache{clusters: goCache, logger: logger}
 }
 
-func newClustersCacheWithExpAndCleanupIntervals(expiration time.Duration, cleanupInterval time.Duration) *ClustersCache {
+func newClustersCacheWithExpAndCleanupIntervals(expiration time.Duration, cleanupInterval time.Duration,
+	logger *zap.SugaredLogger) *ClustersCache {
 	goCache := gocache.New(expiration, cleanupInterval)
-	return &ClustersCache{clusters: goCache}
+	return &ClustersCache{clusters: goCache, logger: logger}
 }
 
 func (cc *ClustersCache) set(cluster *v2.Cluster, ingressName string, ingressNamespace string) {
@@ -61,10 +62,10 @@ func (cc *ClustersCache) setExpiration(clusterName string, ingressName string, i
 
 func (cc *ClustersCache) list() []envoycache.Resource {
 	var res []envoycache.Resource
-	cc.logger.Debugf("listing clusters\n")
+	cc.logger.Debug("listing clusters")
 
 	for _, cluster := range cc.clusters.Items() {
-		cc.logger.Debugf("listing cluster %#v\n", cluster.Object.(*v2.Cluster))
+		cc.logger.Debugf("listing cluster %#v", cluster.Object.(*v2.Cluster))
 		res = append(res, cluster.Object.(envoycache.Resource))
 	}
 

--- a/pkg/generator/cluster_cache_test.go
+++ b/pkg/generator/cluster_cache_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
+
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"gotest.tools/assert"
 )
@@ -18,7 +20,9 @@ var testCluster2 = envoy_api_v2.Cluster{
 }
 
 func TestSetCluster(t *testing.T) {
-	cache := newClustersCache()
+	logger := zap.S()
+
+	cache := newClustersCache(logger)
 	cache.set(&testCluster1, "some_ingress_name", "some_ingress_namespace")
 
 	list := cache.list()
@@ -28,7 +32,9 @@ func TestSetCluster(t *testing.T) {
 }
 
 func TestSetSeveralClusters(t *testing.T) {
-	cache := newClustersCache()
+	logger := zap.S()
+
+	cache := newClustersCache(logger)
 	cache.set(&testCluster1, "some_ingress_name", "some_ingress_namespace")
 	cache.set(&testCluster2, "some_ingress_name", "some_ingress_namespace")
 
@@ -48,8 +54,10 @@ func TestSetSeveralClusters(t *testing.T) {
 }
 
 func TestClustersExpire(t *testing.T) {
+	logger := zap.S()
+
 	cleanupInterval := time.Second
-	cache := newClustersCacheWithExpAndCleanupIntervals(time.Second, cleanupInterval)
+	cache := newClustersCacheWithExpAndCleanupIntervals(time.Second, cleanupInterval, logger)
 	cache.setExpiration(testCluster1.Name, "some_ingress_name", "some_ingress_namespace")
 	time.Sleep(cleanupInterval + time.Second)
 
@@ -59,7 +67,9 @@ func TestClustersExpire(t *testing.T) {
 }
 
 func TestListWhenThereAreNoClusters(t *testing.T) {
-	cache := newClustersCache()
+	logger := zap.S()
+
+	cache := newClustersCache(logger)
 
 	list := cache.list()
 

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -3,6 +3,8 @@ package generator
 import (
 	"testing"
 
+	"go.uber.org/zap"
+
 	"knative.dev/pkg/tracker"
 
 	"k8s.io/client-go/kubernetes"
@@ -33,6 +35,8 @@ import (
 // Note: for now, the name of the cluster is the name of the revision plus the
 // path. That might change in the future.
 func TestTrafficSplits(t *testing.T) {
+	logger := zap.S()
+
 	ingress := v1alpha1.Ingress{
 		TypeMeta: v1.TypeMeta{
 			Kind:       "Ingress",
@@ -100,17 +104,11 @@ func TestTrafficSplits(t *testing.T) {
 		t.Error(err)
 	}
 
-	caches := NewCaches()
+	caches := NewCaches(logger)
 
 	// Check that there is one route in the result
-	if err := UpdateInfoForIngress(
-		caches,
-		&ingress,
-		kubeClient,
-		newMockedEndpointsLister(),
-		"cluster.local",
-		tr,
-	); err != nil {
+	if err := UpdateInfoForIngress(caches, &ingress, kubeClient, newMockedEndpointsLister(), "cluster.local", tr,
+		logger); err != nil {
 		t.Error(err)
 	}
 	assert.Equal(t, 1, len(caches.routes))

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -74,14 +74,8 @@ func (reconciler *Reconciler) deleteIngress(namespace, name string) error {
 func (reconciler *Reconciler) updateIngress(ingress *v1alpha1.Ingress) error {
 	reconciler.logger.Infof("Updating Ingress %s namespace: %s", ingress.Name, ingress.Namespace)
 
-	err := generator.UpdateInfoForIngress(
-		reconciler.CurrentCaches,
-		ingress,
-		reconciler.kubeClient,
-		reconciler.EndpointsLister,
-		network.GetClusterDomainName(),
-		reconciler.tracker,
-	)
+	err := generator.UpdateInfoForIngress(reconciler.CurrentCaches, ingress, reconciler.kubeClient,
+		reconciler.EndpointsLister, network.GetClusterDomainName(), reconciler.tracker, reconciler.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -5,6 +5,8 @@ import (
 	"kourier/pkg/envoy"
 	"kourier/pkg/generator"
 
+	"go.uber.org/zap"
+
 	"knative.dev/pkg/tracker"
 
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
@@ -26,6 +28,7 @@ type Reconciler struct {
 	CurrentCaches   *generator.Caches
 	tracker         tracker.Interface
 	statusManager   *StatusProber
+	logger          *zap.SugaredLogger
 }
 
 func (reconciler *Reconciler) Reconcile(ctx context.Context, key string) error {
@@ -33,6 +36,7 @@ func (reconciler *Reconciler) Reconcile(ctx context.Context, key string) error {
 	if err != nil {
 		return err
 	}
+	reconciler.logger.Infof("Got reconcile request for %s namespace: %s", name, namespace)
 
 	ingress, err := reconciler.IngressLister.Ingresses(namespace).Get(name)
 	if apierrors.IsNotFound(err) {
@@ -45,6 +49,7 @@ func (reconciler *Reconciler) Reconcile(ctx context.Context, key string) error {
 }
 
 func (reconciler *Reconciler) deleteIngress(namespace, name string) error {
+	reconciler.logger.Infof("Deleting Ingress %s namespace: %s", name, namespace)
 	ingress := reconciler.CurrentCaches.GetIngress(name, namespace)
 
 	// We need to check for ingress not being nil, because we can receive an event from an already
@@ -67,6 +72,7 @@ func (reconciler *Reconciler) deleteIngress(namespace, name string) error {
 }
 
 func (reconciler *Reconciler) updateIngress(ingress *v1alpha1.Ingress) error {
+	reconciler.logger.Infof("Updating Ingress %s namespace: %s", ingress.Name, ingress.Namespace)
 
 	err := generator.UpdateInfoForIngress(
 		reconciler.CurrentCaches,


### PR DESCRIPTION
To enable set into the configmap "config-logging" in the kourier-system namespace the zap-logger-config: 

```yaml
data:
      zap-logger-config: |
        {
          "level": "debug",
          "development": false,
          "outputPaths": ["stdout"],
          "errorOutputPaths": ["stderr"],
          "encoding": "json",
          "encoderConfig": {
            "timeKey": "ts",
            "levelKey": "level",
            "nameKey": "logger",
            "callerKey": "caller",
            "messageKey": "msg",
            "stacktraceKey": "stacktrace",
            "lineEnding": "",
            "levelEncoder": "",
            "timeEncoder": "iso8601",
            "durationEncoder": "",
            "callerEncoder": ""
          }
        }
```