### PR TITLE
Fetch gateway ports via the service to guarantee base readiness.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,9 @@
 package config
 
 const (
+	InternalServiceName = "kourier-internal"
+	ExternalServiceName = "kourier"
+
 	HTTPPortExternal  = uint32(8080)
 	HTTPPortInternal  = uint32(8081)
 	HTTPSPortExternal = uint32(8443)

--- a/pkg/knative/ingress.go
+++ b/pkg/knative/ingress.go
@@ -5,20 +5,16 @@ import (
 	"knative.dev/pkg/system"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/client/clientset/versioned"
-)
 
-const (
-	// These 2 are defined in the deployment yaml
-	internalServiceName = "kourier-internal"
-	externalServiceName = "kourier"
+	"kourier/pkg/config"
 )
 
 func MarkIngressReady(knativeClient versioned.Interface, ingress *networkingv1alpha1.Ingress) error {
 	var err error
 	status := ingress.GetStatus()
 	if ingress.GetGeneration() != status.ObservedGeneration || !status.IsReady() {
-		internalDomain := domainForServiceName(internalServiceName)
-		externalDomain := domainForServiceName(externalServiceName)
+		internalDomain := domainForServiceName(config.InternalServiceName)
+		externalDomain := domainForServiceName(config.ExternalServiceName)
 
 		status.InitializeConditions()
 		var domain string

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -71,7 +71,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 	statusProber := NewStatusProber(
 		logger.Named("status-manager"),
-		podInformer.Lister(),
+		endpointsInformer.Lister(),
 		readyCallback)
 
 	c := &Reconciler{


### PR DESCRIPTION
Fetching the pods directly is fine in general but causes us to have to doublecheck pod readiness and availability of an IP. This spares us reimplementing those checks.