### PR TITLE
Update ingress status in the reconcile cycle.

### DIFF
--- a/pkg/knative/ingress.go
+++ b/pkg/knative/ingress.go
@@ -4,51 +4,38 @@ import (
 	"knative.dev/pkg/network"
 	"knative.dev/pkg/system"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
-	"knative.dev/serving/pkg/client/clientset/versioned"
 
 	"kourier/pkg/config"
 )
 
-func MarkIngressReady(knativeClient versioned.Interface, ingress *networkingv1alpha1.Ingress) error {
-	var err error
+func MarkIngressReady(ingress *networkingv1alpha1.Ingress) {
 	status := ingress.GetStatus()
-	if ingress.GetGeneration() != status.ObservedGeneration || !status.IsReady() {
-		internalDomain := domainForServiceName(config.InternalServiceName)
-		externalDomain := domainForServiceName(config.ExternalServiceName)
+	internalDomain := domainForServiceName(config.InternalServiceName)
+	externalDomain := domainForServiceName(config.ExternalServiceName)
 
-		status.InitializeConditions()
-		var domain string
+	status.InitializeConditions()
+	var domain string
 
-		if ingress.GetSpec().Visibility == networkingv1alpha1.IngressVisibilityClusterLocal {
-			domain = internalDomain
-		} else {
-			domain = externalDomain
-		}
-
-		status.MarkLoadBalancerReady(
-			[]networkingv1alpha1.LoadBalancerIngressStatus{
-				{
-					DomainInternal: domain,
-				},
-			},
-			[]networkingv1alpha1.LoadBalancerIngressStatus{
-				{
-					DomainInternal: externalDomain,
-				},
-			},
-			[]networkingv1alpha1.LoadBalancerIngressStatus{
-				{
-					DomainInternal: internalDomain,
-				},
-			})
-		status.MarkNetworkConfigured()
-		status.ObservedGeneration = ingress.GetGeneration()
-		ingress.SetStatus(*status)
-
-		_, err = knativeClient.NetworkingV1alpha1().Ingresses(ingress.GetNamespace()).UpdateStatus(ingress)
-		return err
+	if ingress.GetSpec().Visibility == networkingv1alpha1.IngressVisibilityClusterLocal {
+		domain = internalDomain
+	} else {
+		domain = externalDomain
 	}
-	return nil
+
+	status.MarkLoadBalancerReady(
+		[]networkingv1alpha1.LoadBalancerIngressStatus{{
+			DomainInternal: domain,
+		}},
+		[]networkingv1alpha1.LoadBalancerIngressStatus{{
+			DomainInternal: externalDomain,
+		}},
+		[]networkingv1alpha1.LoadBalancerIngressStatus{{
+			DomainInternal: internalDomain,
+		}},
+	)
+	status.MarkNetworkConfigured()
+	status.ObservedGeneration = ingress.GetGeneration()
+	ingress.SetStatus(*status)
 }
 
 func domainForServiceName(serviceName string) string {


### PR DESCRIPTION
Trying to update status outside of the usual reconcile flow will lead to conflicts where it's unclear how and when those conflicts will be retried.