### PR TITLE
Ensure uniqueness in route names

### DIFF
--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -182,10 +182,6 @@ func (caches *Caches) DeleteIngressInfo(ingressName string, ingressNamespace str
 	return nil
 }
 
-func (caches *Caches) numberOfIngresses() int {
-	return len(caches.ingresses)
-}
-
 func (caches *Caches) deleteTranslatedIngress(ingressName, ingressNamespace string) {
 	caches.logger.Debugf("deleting ingress: %s/%s", ingressName, ingressNamespace)
 

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -69,9 +69,7 @@ func addIngressToCaches(caches *Caches,
 
 	logger.Infof("Knative Ingress found %s/%s", ingress.Name, ingress.Namespace)
 
-	// TODO: is this index really needed?
-	index := caches.numberOfIngresses()
-	ingressTranslation, err := translator.translateIngress(ingress, index, extAuthzEnabled)
+	ingressTranslation, err := translator.translateIngress(ingress, extAuthzEnabled)
 	if err != nil {
 		return err
 	}

--- a/pkg/generator/ingress_translator.go
+++ b/pkg/generator/ingress_translator.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"kourier/pkg/envoy"
 	"kourier/pkg/knative"
-	"strconv"
 	"time"
 
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
@@ -75,7 +74,7 @@ func newTranslatedIngress(ingressName string, ingressNamespace string) translate
 	}
 }
 
-func (translator *IngressTranslator) translateIngress(ingress *v1alpha1.Ingress, index int, extAuthzEnabled bool) (*translatedIngress, error) {
+func (translator *IngressTranslator) translateIngress(ingress *v1alpha1.Ingress, extAuthzEnabled bool) (*translatedIngress, error) {
 	res := newTranslatedIngress(ingress.Name, ingress.Namespace)
 
 	for _, ingressTLS := range ingress.GetSpec().TLS {
@@ -167,7 +166,7 @@ func (translator *IngressTranslator) translateIngress(ingress *v1alpha1.Ingress,
 			}
 
 			if len(wrs) != 0 {
-				r := createRouteForRevision(ingress.Name, index, httpPath, wrs)
+				r := createRouteForRevision(ingress.Name, ingress.Namespace, httpPath, wrs)
 				ruleRoute = append(ruleRoute, r)
 				res.routes = append(res.routes, r)
 			}
@@ -230,8 +229,8 @@ func lbEndpointsForKubeEndpoints(kubeEndpoints *kubev1.Endpoints, targetPort int
 	return publicLbEndpoints
 }
 
-func createRouteForRevision(routeName string, i int, httpPath v1alpha1.HTTPIngressPath, wrs []*route.WeightedCluster_ClusterWeight) *route.Route {
-	name := routeName + "_" + strconv.Itoa(i)
+func createRouteForRevision(ingressName string, ingressNamespace string, httpPath v1alpha1.HTTPIngressPath, wrs []*route.WeightedCluster_ClusterWeight) *route.Route {
+	routeName := ingressName + "_" + ingressNamespace + "_" + httpPath.Path
 
 	path := "/"
 	if httpPath.Path != "" {
@@ -254,7 +253,7 @@ func createRouteForRevision(routeName string, i int, httpPath v1alpha1.HTTPIngre
 	}
 
 	return envoy.NewRoute(
-		name, path, wrs, routeTimeout, uint32(attempts), perTryTimeout, httpPath.AppendHeaders,
+		routeName, path, wrs, routeTimeout, uint32(attempts), perTryTimeout, httpPath.AppendHeaders,
 	)
 }
 

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -122,7 +122,7 @@ func TestTrafficSplits(t *testing.T) {
 	ingressTranslator := NewIngressTranslator(
 		kubeClient, newMockedEndpointsLister(), "cluster.local", tr, logtest.TestLogger(t))
 
-	ingressTranslation, err := ingressTranslator.translateIngress(&ingress, 0, false)
+	ingressTranslation, err := ingressTranslator.translateIngress(&ingress, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -237,7 +237,7 @@ func TestIngressWithTLS(t *testing.T) {
 	ingressTranslator := NewIngressTranslator(
 		kubeClient, newMockedEndpointsLister(), "cluster.local", tr, logtest.TestLogger(t))
 
-	translatedIngress, err := ingressTranslator.translateIngress(&ingress, 0, false)
+	translatedIngress, err := ingressTranslator.translateIngress(&ingress, false)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
This PR uses the ingress name, the namespace, and the path in route names to ensure uniqueness. We were using an "index" before based on the number of ingresses stored in the current config. Apart from complicating the code a bit, using an index alone without taking into account the namespace does not ensure uniqueness.