### PR TITLE
Retry if no gateway pods can be found.

### DIFF
--- a/pkg/reconciler/ingress/status.go
+++ b/pkg/reconciler/ingress/status.go
@@ -174,7 +174,7 @@ func (m *StatusProber) IsReady(ingress *v1alpha1.Ingress) (bool, error) {
 	}
 
 	if len(readyIPs) == 0 {
-		return false, nil
+		return false, fmt.Errorf("no gateway pods available")
 	}
 
 	for _, ip := range readyIPs {


### PR DESCRIPTION
If no gateway pods are up (yet), which happens on a system upgrade, we should retry the reconcilation until we finally find a gateway pod. Returning an error effectively does that. It adds rate limiting too.