### PR TITLE
Reduce errors that fix themselves and make fatal errors more explicit.

### DIFF
--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -73,8 +73,9 @@ func addIngressToCaches(caches *Caches,
 	if err != nil {
 		return err
 	}
-
-	caches.AddTranslatedIngress(ingress, ingressTranslation)
+	if ingressTranslation != nil {
+		caches.AddTranslatedIngress(ingress, ingressTranslation)
+	}
 
 	return nil
 }

--- a/pkg/generator/ingress_translator_test.go
+++ b/pkg/generator/ingress_translator_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	logtest "knative.dev/pkg/logging/testing"
-	"knative.dev/pkg/tracker"
+	pkgtest "knative.dev/pkg/reconciler/testing"
 
 	"k8s.io/client-go/kubernetes"
 
@@ -108,7 +108,6 @@ func TestTrafficSplits(t *testing.T) {
 	}
 
 	kubeClient := fake.NewSimpleClientset()
-	var tr tracker.Interface
 	// Create the Kubernetes services associated to the Knative services that
 	// appear in the ingress above
 	if err := createServicesWithNames(
@@ -120,7 +119,7 @@ func TestTrafficSplits(t *testing.T) {
 	}
 
 	ingressTranslator := NewIngressTranslator(
-		kubeClient, newMockedEndpointsLister(), "cluster.local", tr, logtest.TestLogger(t))
+		kubeClient, newMockedEndpointsLister(), "cluster.local", &pkgtest.FakeTracker{}, logtest.TestLogger(t))
 
 	ingressTranslation, err := ingressTranslator.translateIngress(&ingress, false)
 	if err != nil {
@@ -233,9 +232,8 @@ func TestIngressWithTLS(t *testing.T) {
 		t.Error(err)
 	}
 
-	var tr tracker.Interface
 	ingressTranslator := NewIngressTranslator(
-		kubeClient, newMockedEndpointsLister(), "cluster.local", tr, logtest.TestLogger(t))
+		kubeClient, newMockedEndpointsLister(), "cluster.local", &pkgtest.FakeTracker{}, logtest.TestLogger(t))
 
 	translatedIngress, err := ingressTranslator.translateIngress(&ingress, false)
 	if err != nil {

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/equate.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/equate.go
@@ -1,0 +1,89 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+// Package cmpopts provides common options for the cmp package.
+package cmpopts
+
+import (
+	"math"
+	"reflect"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func equateAlways(_, _ interface{}) bool { return true }
+
+// EquateEmpty returns a Comparer option that determines all maps and slices
+// with a length of zero to be equal, regardless of whether they are nil.
+//
+// EquateEmpty can be used in conjunction with SortSlices and SortMaps.
+func EquateEmpty() cmp.Option {
+	return cmp.FilterValues(isEmpty, cmp.Comparer(equateAlways))
+}
+
+func isEmpty(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	return (x != nil && y != nil && vx.Type() == vy.Type()) &&
+		(vx.Kind() == reflect.Slice || vx.Kind() == reflect.Map) &&
+		(vx.Len() == 0 && vy.Len() == 0)
+}
+
+// EquateApprox returns a Comparer option that determines float32 or float64
+// values to be equal if they are within a relative fraction or absolute margin.
+// This option is not used when either x or y is NaN or infinite.
+//
+// The fraction determines that the difference of two values must be within the
+// smaller fraction of the two values, while the margin determines that the two
+// values must be within some absolute margin.
+// To express only a fraction or only a margin, use 0 for the other parameter.
+// The fraction and margin must be non-negative.
+//
+// The mathematical expression used is equivalent to:
+//	|x-y| ≤ max(fraction*min(|x|, |y|), margin)
+//
+// EquateApprox can be used in conjunction with EquateNaNs.
+func EquateApprox(fraction, margin float64) cmp.Option {
+	if margin < 0 || fraction < 0 || math.IsNaN(margin) || math.IsNaN(fraction) {
+		panic("margin or fraction must be a non-negative number")
+	}
+	a := approximator{fraction, margin}
+	return cmp.Options{
+		cmp.FilterValues(areRealF64s, cmp.Comparer(a.compareF64)),
+		cmp.FilterValues(areRealF32s, cmp.Comparer(a.compareF32)),
+	}
+}
+
+type approximator struct{ frac, marg float64 }
+
+func areRealF64s(x, y float64) bool {
+	return !math.IsNaN(x) && !math.IsNaN(y) && !math.IsInf(x, 0) && !math.IsInf(y, 0)
+}
+func areRealF32s(x, y float32) bool {
+	return areRealF64s(float64(x), float64(y))
+}
+func (a approximator) compareF64(x, y float64) bool {
+	relMarg := a.frac * math.Min(math.Abs(x), math.Abs(y))
+	return math.Abs(x-y) <= math.Max(a.marg, relMarg)
+}
+func (a approximator) compareF32(x, y float32) bool {
+	return a.compareF64(float64(x), float64(y))
+}
+
+// EquateNaNs returns a Comparer option that determines float32 and float64
+// NaN values to be equal.
+//
+// EquateNaNs can be used in conjunction with EquateApprox.
+func EquateNaNs() cmp.Option {
+	return cmp.Options{
+		cmp.FilterValues(areNaNsF64s, cmp.Comparer(equateAlways)),
+		cmp.FilterValues(areNaNsF32s, cmp.Comparer(equateAlways)),
+	}
+}
+
+func areNaNsF64s(x, y float64) bool {
+	return math.IsNaN(x) && math.IsNaN(y)
+}
+func areNaNsF32s(x, y float32) bool {
+	return areNaNsF64s(float64(x), float64(y))
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/ignore.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/ignore.go
@@ -1,0 +1,207 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/internal/function"
+)
+
+// IgnoreFields returns an Option that ignores exported fields of the
+// given names on a single struct type.
+// The struct type is specified by passing in a value of that type.
+//
+// The name may be a dot-delimited string (e.g., "Foo.Bar") to ignore a
+// specific sub-field that is embedded or nested within the parent struct.
+//
+// This does not handle unexported fields; use IgnoreUnexported instead.
+func IgnoreFields(typ interface{}, names ...string) cmp.Option {
+	sf := newStructFilter(typ, names...)
+	return cmp.FilterPath(sf.filter, cmp.Ignore())
+}
+
+// IgnoreTypes returns an Option that ignores all values assignable to
+// certain types, which are specified by passing in a value of each type.
+func IgnoreTypes(typs ...interface{}) cmp.Option {
+	tf := newTypeFilter(typs...)
+	return cmp.FilterPath(tf.filter, cmp.Ignore())
+}
+
+type typeFilter []reflect.Type
+
+func newTypeFilter(typs ...interface{}) (tf typeFilter) {
+	for _, typ := range typs {
+		t := reflect.TypeOf(typ)
+		if t == nil {
+			// This occurs if someone tries to pass in sync.Locker(nil)
+			panic("cannot determine type; consider using IgnoreInterfaces")
+		}
+		tf = append(tf, t)
+	}
+	return tf
+}
+func (tf typeFilter) filter(p cmp.Path) bool {
+	if len(p) < 1 {
+		return false
+	}
+	t := p.Last().Type()
+	for _, ti := range tf {
+		if t.AssignableTo(ti) {
+			return true
+		}
+	}
+	return false
+}
+
+// IgnoreInterfaces returns an Option that ignores all values or references of
+// values assignable to certain interface types. These interfaces are specified
+// by passing in an anonymous struct with the interface types embedded in it.
+// For example, to ignore sync.Locker, pass in struct{sync.Locker}{}.
+func IgnoreInterfaces(ifaces interface{}) cmp.Option {
+	tf := newIfaceFilter(ifaces)
+	return cmp.FilterPath(tf.filter, cmp.Ignore())
+}
+
+type ifaceFilter []reflect.Type
+
+func newIfaceFilter(ifaces interface{}) (tf ifaceFilter) {
+	t := reflect.TypeOf(ifaces)
+	if ifaces == nil || t.Name() != "" || t.Kind() != reflect.Struct {
+		panic("input must be an anonymous struct")
+	}
+	for i := 0; i < t.NumField(); i++ {
+		fi := t.Field(i)
+		switch {
+		case !fi.Anonymous:
+			panic("struct cannot have named fields")
+		case fi.Type.Kind() != reflect.Interface:
+			panic("embedded field must be an interface type")
+		case fi.Type.NumMethod() == 0:
+			// This matches everything; why would you ever want this?
+			panic("cannot ignore empty interface")
+		default:
+			tf = append(tf, fi.Type)
+		}
+	}
+	return tf
+}
+func (tf ifaceFilter) filter(p cmp.Path) bool {
+	if len(p) < 1 {
+		return false
+	}
+	t := p.Last().Type()
+	for _, ti := range tf {
+		if t.AssignableTo(ti) {
+			return true
+		}
+		if t.Kind() != reflect.Ptr && reflect.PtrTo(t).AssignableTo(ti) {
+			return true
+		}
+	}
+	return false
+}
+
+// IgnoreUnexported returns an Option that only ignores the immediate unexported
+// fields of a struct, including anonymous fields of unexported types.
+// In particular, unexported fields within the struct's exported fields
+// of struct types, including anonymous fields, will not be ignored unless the
+// type of the field itself is also passed to IgnoreUnexported.
+//
+// Avoid ignoring unexported fields of a type which you do not control (i.e. a
+// type from another repository), as changes to the implementation of such types
+// may change how the comparison behaves. Prefer a custom Comparer instead.
+func IgnoreUnexported(typs ...interface{}) cmp.Option {
+	ux := newUnexportedFilter(typs...)
+	return cmp.FilterPath(ux.filter, cmp.Ignore())
+}
+
+type unexportedFilter struct{ m map[reflect.Type]bool }
+
+func newUnexportedFilter(typs ...interface{}) unexportedFilter {
+	ux := unexportedFilter{m: make(map[reflect.Type]bool)}
+	for _, typ := range typs {
+		t := reflect.TypeOf(typ)
+		if t == nil || t.Kind() != reflect.Struct {
+			panic(fmt.Sprintf("invalid struct type: %T", typ))
+		}
+		ux.m[t] = true
+	}
+	return ux
+}
+func (xf unexportedFilter) filter(p cmp.Path) bool {
+	sf, ok := p.Index(-1).(cmp.StructField)
+	if !ok {
+		return false
+	}
+	return xf.m[p.Index(-2).Type()] && !isExported(sf.Name())
+}
+
+// isExported reports whether the identifier is exported.
+func isExported(id string) bool {
+	r, _ := utf8.DecodeRuneInString(id)
+	return unicode.IsUpper(r)
+}
+
+// IgnoreSliceElements returns an Option that ignores elements of []V.
+// The discard function must be of the form "func(T) bool" which is used to
+// ignore slice elements of type V, where V is assignable to T.
+// Elements are ignored if the function reports true.
+func IgnoreSliceElements(discardFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(discardFunc)
+	if !function.IsType(vf.Type(), function.ValuePredicate) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid discard function: %T", discardFunc))
+	}
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		si, ok := p.Index(-1).(cmp.SliceIndex)
+		if !ok {
+			return false
+		}
+		if !si.Type().AssignableTo(vf.Type().In(0)) {
+			return false
+		}
+		vx, vy := si.Values()
+		if vx.IsValid() && vf.Call([]reflect.Value{vx})[0].Bool() {
+			return true
+		}
+		if vy.IsValid() && vf.Call([]reflect.Value{vy})[0].Bool() {
+			return true
+		}
+		return false
+	}, cmp.Ignore())
+}
+
+// IgnoreMapEntries returns an Option that ignores entries of map[K]V.
+// The discard function must be of the form "func(T, R) bool" which is used to
+// ignore map entries of type K and V, where K and V are assignable to T and R.
+// Entries are ignored if the function reports true.
+func IgnoreMapEntries(discardFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(discardFunc)
+	if !function.IsType(vf.Type(), function.KeyValuePredicate) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid discard function: %T", discardFunc))
+	}
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		mi, ok := p.Index(-1).(cmp.MapIndex)
+		if !ok {
+			return false
+		}
+		if !mi.Key().Type().AssignableTo(vf.Type().In(0)) || !mi.Type().AssignableTo(vf.Type().In(1)) {
+			return false
+		}
+		k := mi.Key()
+		vx, vy := mi.Values()
+		if vx.IsValid() && vf.Call([]reflect.Value{k, vx})[0].Bool() {
+			return true
+		}
+		if vy.IsValid() && vf.Call([]reflect.Value{k, vy})[0].Bool() {
+			return true
+		}
+		return false
+	}, cmp.Ignore())
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/sort.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/sort.go
@@ -1,0 +1,147 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/internal/function"
+)
+
+// SortSlices returns a Transformer option that sorts all []V.
+// The less function must be of the form "func(T, T) bool" which is used to
+// sort any slice with element type V that is assignable to T.
+//
+// The less function must be:
+//	• Deterministic: less(x, y) == less(x, y)
+//	• Irreflexive: !less(x, x)
+//	• Transitive: if !less(x, y) and !less(y, z), then !less(x, z)
+//
+// The less function does not have to be "total". That is, if !less(x, y) and
+// !less(y, x) for two elements x and y, their relative order is maintained.
+//
+// SortSlices can be used in conjunction with EquateEmpty.
+func SortSlices(lessFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(lessFunc)
+	if !function.IsType(vf.Type(), function.Less) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid less function: %T", lessFunc))
+	}
+	ss := sliceSorter{vf.Type().In(0), vf}
+	return cmp.FilterValues(ss.filter, cmp.Transformer("cmpopts.SortSlices", ss.sort))
+}
+
+type sliceSorter struct {
+	in  reflect.Type  // T
+	fnc reflect.Value // func(T, T) bool
+}
+
+func (ss sliceSorter) filter(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	if !(x != nil && y != nil && vx.Type() == vy.Type()) ||
+		!(vx.Kind() == reflect.Slice && vx.Type().Elem().AssignableTo(ss.in)) ||
+		(vx.Len() <= 1 && vy.Len() <= 1) {
+		return false
+	}
+	// Check whether the slices are already sorted to avoid an infinite
+	// recursion cycle applying the same transform to itself.
+	ok1 := sort.SliceIsSorted(x, func(i, j int) bool { return ss.less(vx, i, j) })
+	ok2 := sort.SliceIsSorted(y, func(i, j int) bool { return ss.less(vy, i, j) })
+	return !ok1 || !ok2
+}
+func (ss sliceSorter) sort(x interface{}) interface{} {
+	src := reflect.ValueOf(x)
+	dst := reflect.MakeSlice(src.Type(), src.Len(), src.Len())
+	for i := 0; i < src.Len(); i++ {
+		dst.Index(i).Set(src.Index(i))
+	}
+	sort.SliceStable(dst.Interface(), func(i, j int) bool { return ss.less(dst, i, j) })
+	ss.checkSort(dst)
+	return dst.Interface()
+}
+func (ss sliceSorter) checkSort(v reflect.Value) {
+	start := -1 // Start of a sequence of equal elements.
+	for i := 1; i < v.Len(); i++ {
+		if ss.less(v, i-1, i) {
+			// Check that first and last elements in v[start:i] are equal.
+			if start >= 0 && (ss.less(v, start, i-1) || ss.less(v, i-1, start)) {
+				panic(fmt.Sprintf("incomparable values detected: want equal elements: %v", v.Slice(start, i)))
+			}
+			start = -1
+		} else if start == -1 {
+			start = i
+		}
+	}
+}
+func (ss sliceSorter) less(v reflect.Value, i, j int) bool {
+	vx, vy := v.Index(i), v.Index(j)
+	return ss.fnc.Call([]reflect.Value{vx, vy})[0].Bool()
+}
+
+// SortMaps returns a Transformer option that flattens map[K]V types to be a
+// sorted []struct{K, V}. The less function must be of the form
+// "func(T, T) bool" which is used to sort any map with key K that is
+// assignable to T.
+//
+// Flattening the map into a slice has the property that cmp.Equal is able to
+// use Comparers on K or the K.Equal method if it exists.
+//
+// The less function must be:
+//	• Deterministic: less(x, y) == less(x, y)
+//	• Irreflexive: !less(x, x)
+//	• Transitive: if !less(x, y) and !less(y, z), then !less(x, z)
+//	• Total: if x != y, then either less(x, y) or less(y, x)
+//
+// SortMaps can be used in conjunction with EquateEmpty.
+func SortMaps(lessFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(lessFunc)
+	if !function.IsType(vf.Type(), function.Less) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid less function: %T", lessFunc))
+	}
+	ms := mapSorter{vf.Type().In(0), vf}
+	return cmp.FilterValues(ms.filter, cmp.Transformer("cmpopts.SortMaps", ms.sort))
+}
+
+type mapSorter struct {
+	in  reflect.Type  // T
+	fnc reflect.Value // func(T, T) bool
+}
+
+func (ms mapSorter) filter(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	return (x != nil && y != nil && vx.Type() == vy.Type()) &&
+		(vx.Kind() == reflect.Map && vx.Type().Key().AssignableTo(ms.in)) &&
+		(vx.Len() != 0 || vy.Len() != 0)
+}
+func (ms mapSorter) sort(x interface{}) interface{} {
+	src := reflect.ValueOf(x)
+	outType := reflect.StructOf([]reflect.StructField{
+		{Name: "K", Type: src.Type().Key()},
+		{Name: "V", Type: src.Type().Elem()},
+	})
+	dst := reflect.MakeSlice(reflect.SliceOf(outType), src.Len(), src.Len())
+	for i, k := range src.MapKeys() {
+		v := reflect.New(outType).Elem()
+		v.Field(0).Set(k)
+		v.Field(1).Set(src.MapIndex(k))
+		dst.Index(i).Set(v)
+	}
+	sort.Slice(dst.Interface(), func(i, j int) bool { return ms.less(dst, i, j) })
+	ms.checkSort(dst)
+	return dst.Interface()
+}
+func (ms mapSorter) checkSort(v reflect.Value) {
+	for i := 1; i < v.Len(); i++ {
+		if !ms.less(v, i-1, i) {
+			panic(fmt.Sprintf("partial order detected: want %v < %v", v.Index(i-1), v.Index(i)))
+		}
+	}
+}
+func (ms mapSorter) less(v reflect.Value, i, j int) bool {
+	vx, vy := v.Index(i).Field(0), v.Index(j).Field(0)
+	return ms.fnc.Call([]reflect.Value{vx, vy})[0].Bool()
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/struct_filter.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/struct_filter.go
@@ -1,0 +1,182 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// filterField returns a new Option where opt is only evaluated on paths that
+// include a specific exported field on a single struct type.
+// The struct type is specified by passing in a value of that type.
+//
+// The name may be a dot-delimited string (e.g., "Foo.Bar") to select a
+// specific sub-field that is embedded or nested within the parent struct.
+func filterField(typ interface{}, name string, opt cmp.Option) cmp.Option {
+	// TODO: This is currently unexported over concerns of how helper filters
+	// can be composed together easily.
+	// TODO: Add tests for FilterField.
+
+	sf := newStructFilter(typ, name)
+	return cmp.FilterPath(sf.filter, opt)
+}
+
+type structFilter struct {
+	t  reflect.Type // The root struct type to match on
+	ft fieldTree    // Tree of fields to match on
+}
+
+func newStructFilter(typ interface{}, names ...string) structFilter {
+	// TODO: Perhaps allow * as a special identifier to allow ignoring any
+	// number of path steps until the next field match?
+	// This could be useful when a concrete struct gets transformed into
+	// an anonymous struct where it is not possible to specify that by type,
+	// but the transformer happens to provide guarantees about the names of
+	// the transformed fields.
+
+	t := reflect.TypeOf(typ)
+	if t == nil || t.Kind() != reflect.Struct {
+		panic(fmt.Sprintf("%T must be a struct", typ))
+	}
+	var ft fieldTree
+	for _, name := range names {
+		cname, err := canonicalName(t, name)
+		if err != nil {
+			panic(fmt.Sprintf("%s: %v", strings.Join(cname, "."), err))
+		}
+		ft.insert(cname)
+	}
+	return structFilter{t, ft}
+}
+
+func (sf structFilter) filter(p cmp.Path) bool {
+	for i, ps := range p {
+		if ps.Type().AssignableTo(sf.t) && sf.ft.matchPrefix(p[i+1:]) {
+			return true
+		}
+	}
+	return false
+}
+
+// fieldTree represents a set of dot-separated identifiers.
+//
+// For example, inserting the following selectors:
+//	Foo
+//	Foo.Bar.Baz
+//	Foo.Buzz
+//	Nuka.Cola.Quantum
+//
+// Results in a tree of the form:
+//	{sub: {
+//		"Foo": {ok: true, sub: {
+//			"Bar": {sub: {
+//				"Baz": {ok: true},
+//			}},
+//			"Buzz": {ok: true},
+//		}},
+//		"Nuka": {sub: {
+//			"Cola": {sub: {
+//				"Quantum": {ok: true},
+//			}},
+//		}},
+//	}}
+type fieldTree struct {
+	ok  bool                 // Whether this is a specified node
+	sub map[string]fieldTree // The sub-tree of fields under this node
+}
+
+// insert inserts a sequence of field accesses into the tree.
+func (ft *fieldTree) insert(cname []string) {
+	if ft.sub == nil {
+		ft.sub = make(map[string]fieldTree)
+	}
+	if len(cname) == 0 {
+		ft.ok = true
+		return
+	}
+	sub := ft.sub[cname[0]]
+	sub.insert(cname[1:])
+	ft.sub[cname[0]] = sub
+}
+
+// matchPrefix reports whether any selector in the fieldTree matches
+// the start of path p.
+func (ft fieldTree) matchPrefix(p cmp.Path) bool {
+	for _, ps := range p {
+		switch ps := ps.(type) {
+		case cmp.StructField:
+			ft = ft.sub[ps.Name()]
+			if ft.ok {
+				return true
+			}
+			if len(ft.sub) == 0 {
+				return false
+			}
+		case cmp.Indirect:
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// canonicalName returns a list of identifiers where any struct field access
+// through an embedded field is expanded to include the names of the embedded
+// types themselves.
+//
+// For example, suppose field "Foo" is not directly in the parent struct,
+// but actually from an embedded struct of type "Bar". Then, the canonical name
+// of "Foo" is actually "Bar.Foo".
+//
+// Suppose field "Foo" is not directly in the parent struct, but actually
+// a field in two different embedded structs of types "Bar" and "Baz".
+// Then the selector "Foo" causes a panic since it is ambiguous which one it
+// refers to. The user must specify either "Bar.Foo" or "Baz.Foo".
+func canonicalName(t reflect.Type, sel string) ([]string, error) {
+	var name string
+	sel = strings.TrimPrefix(sel, ".")
+	if sel == "" {
+		return nil, fmt.Errorf("name must not be empty")
+	}
+	if i := strings.IndexByte(sel, '.'); i < 0 {
+		name, sel = sel, ""
+	} else {
+		name, sel = sel[:i], sel[i:]
+	}
+
+	// Type must be a struct or pointer to struct.
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("%v must be a struct", t)
+	}
+
+	// Find the canonical name for this current field name.
+	// If the field exists in an embedded struct, then it will be expanded.
+	if !isExported(name) {
+		// Disallow unexported fields:
+		//	* To discourage people from actually touching unexported fields
+		//	* FieldByName is buggy (https://golang.org/issue/4876)
+		return []string{name}, fmt.Errorf("name must be exported")
+	}
+	sf, ok := t.FieldByName(name)
+	if !ok {
+		return []string{name}, fmt.Errorf("does not exist")
+	}
+	var ss []string
+	for i := range sf.Index {
+		ss = append(ss, t.FieldByIndex(sf.Index[:i+1]).Name)
+	}
+	if sel == "" {
+		return ss, nil
+	}
+	ssPost, err := canonicalName(sf.Type, sel)
+	return append(ss, ssPost...), err
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/xform.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/xform.go
@@ -1,0 +1,35 @@
+// Copyright 2018, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmpopts
+
+import (
+	"github.com/google/go-cmp/cmp"
+)
+
+type xformFilter struct{ xform cmp.Option }
+
+func (xf xformFilter) filter(p cmp.Path) bool {
+	for _, ps := range p {
+		if t, ok := ps.(cmp.Transform); ok && t.Option() == xf.xform {
+			return false
+		}
+	}
+	return true
+}
+
+// AcyclicTransformer returns a Transformer with a filter applied that ensures
+// that the transformer cannot be recursively applied upon its own output.
+//
+// An example use case is a transformer that splits a string by lines:
+//	AcyclicTransformer("SplitLines", func(s string) []string{
+//		return strings.Split(s, "\n")
+//	})
+//
+// Had this been an unfiltered Transformer instead, this would result in an
+// infinite cycle converting a string to []string to [][]string and so on.
+func AcyclicTransformer(name string, xformFunc interface{}) cmp.Option {
+	xf := xformFilter{cmp.Transformer(name, xformFunc)}
+	return cmp.FilterPath(xf.filter, xf.xform)
+}

--- a/vendor/knative.dev/pkg/reconciler/testing/actions.go
+++ b/vendor/knative.dev/pkg/reconciler/testing/actions.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+
+	clientgotesting "k8s.io/client-go/testing"
+)
+
+// Actions stores list of Actions recorded by the reactors.
+type Actions struct {
+	Gets              []clientgotesting.GetAction
+	Creates           []clientgotesting.CreateAction
+	Updates           []clientgotesting.UpdateAction
+	Deletes           []clientgotesting.DeleteAction
+	DeleteCollections []clientgotesting.DeleteCollectionAction
+	Patches           []clientgotesting.PatchAction
+}
+
+// ActionRecorder contains list of K8s request actions.
+type ActionRecorder interface {
+	Actions() []clientgotesting.Action
+}
+
+// ActionRecorderList is a list of ActionRecorder objects.
+type ActionRecorderList []ActionRecorder
+
+// ActionsByVerb fills in Actions objects, sorting the actions
+// by verb.
+func (l ActionRecorderList) ActionsByVerb() (Actions, error) {
+	var a Actions
+
+	for _, recorder := range l {
+		for _, action := range recorder.Actions() {
+			switch action.GetVerb() {
+			case "get":
+				a.Gets = append(a.Gets,
+					action.(clientgotesting.GetAction))
+			case "create":
+				a.Creates = append(a.Creates,
+					action.(clientgotesting.CreateAction))
+			case "update":
+				a.Updates = append(a.Updates,
+					action.(clientgotesting.UpdateAction))
+			case "delete":
+				a.Deletes = append(a.Deletes,
+					action.(clientgotesting.DeleteAction))
+			case "delete-collection":
+				a.DeleteCollections = append(a.DeleteCollections,
+					action.(clientgotesting.DeleteCollectionAction))
+			case "patch":
+				a.Patches = append(a.Patches,
+					action.(clientgotesting.PatchAction))
+			case "list", "watch": // avoid 'unexpected verb list/watch' error
+			default:
+				return a, fmt.Errorf("unexpected verb %v: %+v", action.GetVerb(), action)
+			}
+		}
+	}
+	return a, nil
+}

--- a/vendor/knative.dev/pkg/reconciler/testing/clock.go
+++ b/vendor/knative.dev/pkg/reconciler/testing/clock.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"time"
+)
+
+type FakeClock struct {
+	Time time.Time
+}
+
+func (c FakeClock) Now() time.Time {
+	return c.Time
+}

--- a/vendor/knative.dev/pkg/reconciler/testing/context.go
+++ b/vendor/knative.dev/pkg/reconciler/testing/context.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+// SetupFakeContext sets up the the Context and the fake informers for the tests.
+func SetupFakeContext(t *testing.T) (context.Context, []controller.Informer) {
+	c, _, is := SetupFakeContextWithCancel(t)
+	return c, is
+}
+
+// SetupFakeContextWithCancel sets up the the Context and the fake informers for the tests
+// The provided context can be canceled using provided callback.
+func SetupFakeContextWithCancel(t *testing.T) (context.Context, context.CancelFunc, []controller.Informer) {
+	ctx, c := context.WithCancel(logtesting.TestContextWithLogger(t))
+	ctx = controller.WithEventRecorder(ctx, record.NewFakeRecorder(1000))
+	ctx, is := injection.Fake.SetupInformers(ctx, &rest.Config{})
+	return ctx, c, is
+}

--- a/vendor/knative.dev/pkg/reconciler/testing/events.go
+++ b/vendor/knative.dev/pkg/reconciler/testing/events.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/tools/record"
+)
+
+// EventList exports all events during reconciliation through fake event recorder
+// with event channel with buffer of given size.
+type EventList struct {
+	Recorder *record.FakeRecorder
+}
+
+// Events iterates over events received from channel in fake event recorder and returns all.
+func (l EventList) Events() []string {
+	close(l.Recorder.Events)
+	events := []string{}
+	for e := range l.Recorder.Events {
+		events = append(events, e)
+	}
+	return events
+}
+
+// Eventf formats as FakeRecorder does.
+func Eventf(eventType, reason, messageFmt string, args ...interface{}) string {
+	return fmt.Sprintf(eventType+" "+reason+" "+messageFmt, args...)
+}

--- a/vendor/knative.dev/pkg/reconciler/testing/generate_name_reactor.go
+++ b/vendor/knative.dev/pkg/reconciler/testing/generate_name_reactor.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgotesting "k8s.io/client-go/testing"
+)
+
+// GenerateNameReactor will simulate the k8s API server
+// and generate a name for resources who's metadata.generateName
+// property is set. This happens only for CreateAction types
+//
+// This generator is deterministic (unliked k8s) and uses a global
+// counter to help make test names predictable
+type GenerateNameReactor struct {
+	count int64
+}
+
+// Handles contains all the logic to generate the name and mutates
+// the create action object
+//
+// This is a hack as 'React' is passed a DeepCopy of the action hence
+// this is the only opportunity to 'mutate' the action in the
+// ReactionChain and have to continue executing additional reactors
+//
+// We should push changes upstream to client-go to help us with
+// mocking
+func (r *GenerateNameReactor) Handles(action clientgotesting.Action) bool {
+	create, ok := action.(clientgotesting.CreateAction)
+	if !ok {
+		return false
+	}
+
+	objMeta, err := meta.Accessor(create.GetObject())
+	if err != nil {
+		return false
+	}
+
+	if objMeta.GetName() != "" {
+		return false
+	}
+
+	if objMeta.GetGenerateName() == "" {
+		return false
+	}
+
+	val := atomic.AddInt64(&r.count, 1)
+
+	objMeta.SetName(fmt.Sprintf("%s%05d", objMeta.GetGenerateName(), val))
+
+	return false
+}
+
+// React is noop-function
+func (r *GenerateNameReactor) React(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+	return false, nil, nil
+}
+
+var _ clientgotesting.Reactor = (*GenerateNameReactor)(nil)
+
+// PrependGenerateNameReactor will instrument a client-go testing Fake
+// with a reactor that simulates 'generateName' functionality
+func PrependGenerateNameReactor(f *clientgotesting.Fake) {
+	f.ReactionChain = append([]clientgotesting.Reactor{&GenerateNameReactor{}}, f.ReactionChain...)
+}

--- a/vendor/knative.dev/pkg/reconciler/testing/hooks.go
+++ b/vendor/knative.dev/pkg/reconciler/testing/hooks.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package testing includes utilities for testing controllers.
+package testing
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	kubetesting "k8s.io/client-go/testing"
+)
+
+// HookResult is the return value of hook functions.
+type HookResult bool
+
+const (
+	// HookComplete indicates the hook function completed, and WaitForHooks should
+	// not wait for it.
+	HookComplete HookResult = true
+	// HookIncomplete indicates the hook function is incomplete, and WaitForHooks
+	// should wait for it to complete.
+	HookIncomplete HookResult = false
+)
+
+/*
+CreateHookFunc is a function for handling a Create hook. Its runtime.Object
+parameter will be the Kubernetes resource created. The resource can be cast
+to its actual type like this:
+
+		pod := obj.(*v1.Pod)
+
+A return value of true marks the hook as completed. Returning false allows
+the hook to run again when the next resource of the requested type is
+created.
+*/
+type CreateHookFunc func(runtime.Object) HookResult
+
+/*
+UpdateHookFunc is a function for handling an update hook. its runtime.Object
+parameter will be the Kubernetes resource updated. The resource can be cast
+to its actual type like this:
+
+		pod := obj.(*v1.Pod)
+
+A return value of true marks the hook as completed. Returning false allows
+the hook to run again when the next resource of the requested type is
+updated.
+*/
+type UpdateHookFunc func(runtime.Object) HookResult
+
+/*
+DeleteHookFunc is a function for handling a delete hook. Its name parameter will
+be the name of the resource deleted. The resource itself is not available to
+the reactor.
+*/
+type DeleteHookFunc func(string) HookResult
+
+/*
+Hooks is a utility struct that simplifies controller testing with fake
+clients. A Hooks struct allows attaching hook functions to actions (create,
+update, delete) on a specified resource type within a fake client and ensuring
+that all hooks complete in a timely manner.
+*/
+type Hooks struct {
+	completionCh    chan int32
+	completionIndex int32
+
+	// Denotes whether or not the registered hooks should no longer be called
+	// because they have already been waited upon.
+	// This uses a Mutex over a channel to guarantee that after WaitForHooks
+	// returns no hooked functions will be called.
+	closed bool
+	mutex  sync.RWMutex
+}
+
+// NewHooks returns a Hooks struct that can be used to attach hooks to one or
+// more fake clients and wait for all hooks to complete.
+// TODO(grantr): Allow validating that a hook never fires
+func NewHooks() *Hooks {
+	return &Hooks{
+		completionCh:    make(chan int32, 100),
+		completionIndex: -1,
+	}
+}
+
+// OnCreate attaches a create hook to the given Fake. The hook function is
+// executed every time a resource of the given type is created.
+func (h *Hooks) OnCreate(fake *kubetesting.Fake, resource string, rf CreateHookFunc) {
+	index := atomic.AddInt32(&h.completionIndex, 1)
+	fake.PrependReactor("create", resource, func(a kubetesting.Action) (bool, runtime.Object, error) {
+		obj := a.(kubetesting.CreateActionImpl).Object
+
+		h.mutex.RLock()
+		defer h.mutex.RUnlock()
+		if !h.closed && rf(obj) == HookComplete {
+			h.completionCh <- index
+		}
+		return false, nil, nil
+	})
+}
+
+// OnUpdate attaches an update hook to the given Fake. The hook function is
+// executed every time a resource of the given type is updated.
+func (h *Hooks) OnUpdate(fake *kubetesting.Fake, resource string, rf UpdateHookFunc) {
+	index := atomic.AddInt32(&h.completionIndex, 1)
+	fake.PrependReactor("update", resource, func(a kubetesting.Action) (bool, runtime.Object, error) {
+		obj := a.(kubetesting.UpdateActionImpl).Object
+
+		h.mutex.RLock()
+		defer h.mutex.RUnlock()
+		if !h.closed && rf(obj) == HookComplete {
+			h.completionCh <- index
+		}
+		return false, nil, nil
+	})
+}
+
+// OnDelete attaches a delete hook to the given Fake. The hook function is
+// executed every time a resource of the given type is deleted.
+func (h *Hooks) OnDelete(fake *kubetesting.Fake, resource string, rf DeleteHookFunc) {
+	index := atomic.AddInt32(&h.completionIndex, 1)
+	fake.PrependReactor("delete", resource, func(a kubetesting.Action) (bool, runtime.Object, error) {
+		name := a.(kubetesting.DeleteActionImpl).Name
+
+		h.mutex.RLock()
+		defer h.mutex.RUnlock()
+		if !h.closed && rf(name) == HookComplete {
+			h.completionCh <- index
+		}
+		return false, nil, nil
+	})
+}
+
+// WaitForHooks waits until all attached hooks have returned true at least once.
+// If the given timeout expires before that happens, an error is returned.
+// The registered actions will no longer be executed after WaitForHooks has
+// returned.
+func (h *Hooks) WaitForHooks(timeout time.Duration) error {
+	defer func() {
+		h.mutex.Lock()
+		defer h.mutex.Unlock()
+		h.closed = true
+	}()
+
+	ci := int(atomic.LoadInt32(&h.completionIndex))
+	if ci == -1 {
+		return nil
+	}
+
+	// Convert index to count.
+	ci++
+	timer := time.After(timeout)
+	hookCompletions := map[int32]HookResult{}
+	for {
+		select {
+		case i := <-h.completionCh:
+			hookCompletions[i] = HookComplete
+			if len(hookCompletions) == ci {
+				atomic.StoreInt32(&h.completionIndex, -1)
+				return nil
+			}
+		case <-timer:
+			return errors.New("timed out waiting for hooks to complete")
+		}
+	}
+}

--- a/vendor/knative.dev/pkg/reconciler/testing/reactions.go
+++ b/vendor/knative.dev/pkg/reconciler/testing/reactions.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgotesting "k8s.io/client-go/testing"
+
+	"knative.dev/pkg/apis"
+)
+
+// InduceFailure is used in conjunction with TableTest's WithReactors field.
+// Tests that want to induce a failure in a row of a TableTest would add:
+//   WithReactors: []clientgotesting.ReactionFunc{
+//      // Makes calls to create revisions return an error.
+//      InduceFailure("create", "revisions"),
+//   },
+func InduceFailure(verb, resource string) clientgotesting.ReactionFunc {
+	return func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+		if !action.Matches(verb, resource) {
+			return false, nil, nil
+		}
+		return true, nil, fmt.Errorf("inducing failure for %s %s", action.GetVerb(), action.GetResource().Resource)
+	}
+}
+
+func ValidateCreates(ctx context.Context, action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+	got := action.(clientgotesting.CreateAction).GetObject()
+	obj, ok := got.(apis.Validatable)
+	if !ok {
+		return false, nil, nil
+	}
+	if err := obj.Validate(ctx); err != nil {
+		return true, nil, err
+	}
+	return false, nil, nil
+}
+
+func ValidateUpdates(ctx context.Context, action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+	got := action.(clientgotesting.UpdateAction).GetObject()
+	obj, ok := got.(apis.Validatable)
+	if !ok {
+		return false, nil, nil
+	}
+	if err := obj.Validate(ctx); err != nil {
+		return true, nil, err
+	}
+	return false, nil, nil
+}

--- a/vendor/knative.dev/pkg/reconciler/testing/sorter.go
+++ b/vendor/knative.dev/pkg/reconciler/testing/sorter.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package testing
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	util_runtime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+func NewObjectSorter(scheme *runtime.Scheme) ObjectSorter {
+	cache := make(map[reflect.Type]cache.Indexer)
+
+	for _, v := range scheme.AllKnownTypes() {
+		cache[v] = emptyIndexer()
+	}
+
+	ls := ObjectSorter{
+		cache: cache,
+	}
+
+	return ls
+}
+
+type ObjectSorter struct {
+	cache map[reflect.Type]cache.Indexer
+}
+
+func (o *ObjectSorter) AddObjects(objs ...runtime.Object) {
+	for _, obj := range objs {
+		t := reflect.TypeOf(obj).Elem()
+		indexer, ok := o.cache[t]
+		if !ok {
+			panic(fmt.Sprintf("Unrecognized type %T", obj))
+		}
+		indexer.Add(obj)
+	}
+}
+
+func (o *ObjectSorter) ObjectsForScheme(scheme *runtime.Scheme) []runtime.Object {
+	var objs []runtime.Object
+
+	for _, t := range scheme.AllKnownTypes() {
+		indexer := o.cache[t]
+		for _, item := range indexer.List() {
+			objs = append(objs, item.(runtime.Object))
+		}
+	}
+
+	return objs
+}
+
+func (o *ObjectSorter) ObjectsForSchemeFunc(funcs ...func(scheme *runtime.Scheme) error) []runtime.Object {
+	scheme := runtime.NewScheme()
+
+	for _, addToScheme := range funcs {
+		util_runtime.Must(addToScheme(scheme))
+	}
+
+	return o.ObjectsForScheme(scheme)
+}
+
+func (o *ObjectSorter) IndexerForObjectType(obj runtime.Object) cache.Indexer {
+	objType := reflect.TypeOf(obj).Elem()
+
+	indexer, ok := o.cache[objType]
+
+	if !ok {
+		panic(fmt.Sprintf("indexer for type %v doesn't exist", objType.Name()))
+	}
+
+	return indexer
+}
+
+func emptyIndexer() cache.Indexer {
+	return cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+}

--- a/vendor/knative.dev/pkg/reconciler/testing/stats.go
+++ b/vendor/knative.dev/pkg/reconciler/testing/stats.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+	"time"
+)
+
+// FakeStatsReporter is a fake implementation of StatsReporter
+type FakeStatsReporter struct {
+	servicesReady map[string]int
+}
+
+func (r *FakeStatsReporter) ReportServiceReady(namespace, service string, d time.Duration) error {
+	key := fmt.Sprintf("%s/%s", namespace, service)
+	if r.servicesReady == nil {
+		r.servicesReady = make(map[string]int)
+	}
+	r.servicesReady[key]++
+	return nil
+}
+
+func (r *FakeStatsReporter) GetServiceReadyStats() map[string]int {
+	return r.servicesReady
+}

--- a/vendor/knative.dev/pkg/reconciler/testing/table.go
+++ b/vendor/knative.dev/pkg/reconciler/testing/table.go
@@ -1,0 +1,408 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"path"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"go.uber.org/zap"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgotesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/logging/logkey"
+	_ "knative.dev/pkg/system/testing" // Setup system.Namespace()
+)
+
+// TableRow holds a single row of our table test.
+type TableRow struct {
+	// Name is a descriptive name for this test suitable as a first argument to t.Run()
+	Name string
+
+	// Ctx is the context to pass to Reconcile. Defaults to context.Background()
+	Ctx context.Context
+
+	// Objects holds the state of the world at the onset of reconciliation.
+	Objects []runtime.Object
+
+	// Key is the parameter to reconciliation.
+	// This has the form "namespace/name".
+	Key string
+
+	// WantErr holds whether we should expect the reconciliation to result in an error.
+	WantErr bool
+
+	// WantCreates holds the ordered list of Create calls we expect during reconciliation.
+	WantCreates []runtime.Object
+
+	// WantUpdates holds the ordered list of Update calls we expect during reconciliation.
+	WantUpdates []clientgotesting.UpdateActionImpl
+
+	// WantStatusUpdates holds the ordered list of Update calls, with `status` subresource set,
+	// that we expect during reconciliation.
+	WantStatusUpdates []clientgotesting.UpdateActionImpl
+
+	// WantDeletes holds the ordered list of Delete calls we expect during reconciliation.
+	WantDeletes []clientgotesting.DeleteActionImpl
+
+	// WantDeleteCollections holds the ordered list of DeleteCollection calls we expect during reconciliation.
+	WantDeleteCollections []clientgotesting.DeleteCollectionActionImpl
+
+	// WantPatches holds the ordered list of Patch calls we expect during reconciliation.
+	WantPatches []clientgotesting.PatchActionImpl
+
+	// WantEvents holds the ordered list of events we expect during reconciliation.
+	WantEvents []string
+
+	// WantServiceReadyStats holds the ServiceReady stats we expect during reconciliation.
+	WantServiceReadyStats map[string]int
+
+	// WithReactors is a set of functions that are installed as Reactors for the execution
+	// of this row of the table-driven-test.
+	WithReactors []clientgotesting.ReactionFunc
+
+	// For cluster-scoped resources like ClusterIngress, it does not have to be
+	// in the same namespace with its child resources.
+	SkipNamespaceValidation bool
+
+	// PostConditions allows custom assertions to be made after reconciliation
+	PostConditions []func(*testing.T, *TableRow)
+
+	// Reconciler holds the controller.Reconciler that was used to evaluate this row.
+	// It is populated here to make it accessible to PostConditions.
+	Reconciler controller.Reconciler
+
+	// OtherTestData is arbitrary data needed for the test. It is not used directly by the table
+	// testing framework. Instead it is used in the test method. E.g. setting up the responses for a
+	// mock client can go in here.
+	OtherTestData map[string]interface{}
+}
+
+func objKey(o runtime.Object) string {
+	on := o.(kmeta.Accessor)
+
+	var typeOf string
+	if gvk := on.GroupVersionKind(); gvk.Group != "" {
+		// This must be populated if we're dealing with unstructured.Unstructured.
+		typeOf = gvk.String()
+	} else if or, ok := on.(kmeta.OwnerRefable); ok {
+		// This is typically implemented by Knative resources.
+		typeOf = or.GetGroupVersionKind().String()
+	} else {
+		// Worst case, fallback on a non-GVK string.
+		typeOf = reflect.TypeOf(o).String()
+	}
+
+	// namespace + name is not unique, and the tests don't populate k8s kind
+	// information, so use GoLang's type name as part of the key.
+	return path.Join(typeOf, on.GetNamespace(), on.GetName())
+}
+
+// Factory returns a Reconciler.Interface to perform reconciliation in table test,
+// ActionRecorderList/EventList to capture k8s actions/events produced during reconciliation
+// and FakeStatsReporter to capture stats.
+type Factory func(*testing.T, *TableRow) (controller.Reconciler, ActionRecorderList, EventList, *FakeStatsReporter)
+
+// Test executes the single table test.
+func (r *TableRow) Test(t *testing.T, factory Factory) {
+	t.Helper()
+	c, recorderList, eventList, statsReporter := factory(t, r)
+
+	// Set the Reconciler for PostConditions to access it post-Reconcile()
+	r.Reconciler = c
+
+	// Set context to not be nil.
+	ctx := r.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	} else {
+		// If we have logger setup on the context, decorate it with the key, so that the logs
+		// look like in prod.
+		l := logging.FromContext(ctx)
+		l = l.With(zap.String(logkey.Key, r.Key))
+		ctx = logging.WithLogger(ctx, l)
+	}
+
+	// Run the Reconcile we're testing.
+	if err := c.Reconcile(ctx, r.Key); (err != nil) != r.WantErr {
+		t.Errorf("Reconcile() error = %v, WantErr %v", err, r.WantErr)
+	}
+
+	expectedNamespace, _, _ := cache.SplitMetaNamespaceKey(r.Key)
+
+	actions, err := recorderList.ActionsByVerb()
+	if err != nil {
+		t.Errorf("Error capturing actions by verb: %q", err)
+	}
+
+	// Previous state is used to diff resource expected state for update requests that were missed.
+	objPrevState := make(map[string]runtime.Object, len(r.Objects))
+	for _, o := range r.Objects {
+		objPrevState[objKey(o)] = o
+	}
+
+	for i, want := range r.WantCreates {
+		if i >= len(actions.Creates) {
+			t.Errorf("Missing create: %#v", want)
+			continue
+		}
+		got := actions.Creates[i]
+		obj := got.GetObject()
+		objPrevState[objKey(obj)] = obj
+
+		if !r.SkipNamespaceValidation && got.GetNamespace() != expectedNamespace {
+			t.Errorf("Unexpected action[%d]: %#v", i, got)
+		}
+
+		if diff := cmp.Diff(want, obj, ignoreLastTransitionTime, safeDeployDiff, cmpopts.EquateEmpty()); diff != "" {
+			t.Errorf("Unexpected create (-want, +got): %s", diff)
+		}
+	}
+	if got, want := len(actions.Creates), len(r.WantCreates); got > want {
+		for _, extra := range actions.Creates[want:] {
+			t.Errorf("Extra create: %#v", extra.GetObject())
+		}
+	}
+
+	updates := filterUpdatesWithSubresource("", actions.Updates)
+	for i, want := range r.WantUpdates {
+		if i >= len(updates) {
+			wo := want.GetObject()
+			key := objKey(wo)
+			oldObj, ok := objPrevState[key]
+			if !ok {
+				t.Errorf("Object %s was never created: want: %#v", key, wo)
+				continue
+			}
+			t.Errorf("Missing update for %s (-want, +prevState): %s", key,
+				cmp.Diff(wo, oldObj, ignoreLastTransitionTime, safeDeployDiff, cmpopts.EquateEmpty()))
+			continue
+		}
+
+		if want.GetSubresource() != "" {
+			t.Errorf("Expectation was invalid - it should not include a subresource: %#v", want)
+		}
+
+		got := updates[i].GetObject()
+
+		// Update the object state.
+		objPrevState[objKey(got)] = got
+
+		if diff := cmp.Diff(want.GetObject(), got, ignoreLastTransitionTime, safeDeployDiff, cmpopts.EquateEmpty()); diff != "" {
+			t.Errorf("Unexpected update (-want, +got): %s", diff)
+		}
+	}
+	if got, want := len(updates), len(r.WantUpdates); got > want {
+		for _, extra := range updates[want:] {
+			t.Errorf("Extra update: %#v", extra.GetObject())
+		}
+	}
+
+	// TODO(#2843): refactor.
+	statusUpdates := filterUpdatesWithSubresource("status", actions.Updates)
+	for i, want := range r.WantStatusUpdates {
+		if i >= len(statusUpdates) {
+			wo := want.GetObject()
+			key := objKey(wo)
+			oldObj, ok := objPrevState[key]
+			if !ok {
+				t.Errorf("Object %s was never created: want: %#v", key, wo)
+				continue
+			}
+			t.Errorf("Missing status update for %s (-want, +prevState): %s", key,
+				cmp.Diff(wo, oldObj, ignoreLastTransitionTime, safeDeployDiff, cmpopts.EquateEmpty()))
+			continue
+		}
+
+		got := statusUpdates[i].GetObject()
+
+		// Update the object state.
+		objPrevState[objKey(got)] = got
+
+		if diff := cmp.Diff(want.GetObject(), got, ignoreLastTransitionTime, safeDeployDiff, cmpopts.EquateEmpty()); diff != "" {
+			t.Errorf("Unexpected status update (-want, +got): %s\nFull: %v", diff, got)
+		}
+	}
+	if got, want := len(statusUpdates), len(r.WantStatusUpdates); got > want {
+		for _, extra := range statusUpdates[want:] {
+			wo := extra.GetObject()
+			key := objKey(wo)
+			oldObj, ok := objPrevState[key]
+			if !ok {
+				t.Errorf("Object %s was never created: want: %#v", key, wo)
+				continue
+			}
+			t.Errorf("Extra status update for %s (-extra, +prevState): %s", key,
+				cmp.Diff(wo, oldObj, ignoreLastTransitionTime, safeDeployDiff, cmpopts.EquateEmpty()))
+		}
+	}
+
+	if len(statusUpdates)+len(updates) != len(actions.Updates) {
+		var unexpected []runtime.Object
+
+		for _, update := range actions.Updates {
+			if update.GetSubresource() != "status" && update.GetSubresource() != "" {
+				unexpected = append(unexpected, update.GetObject())
+			}
+		}
+
+		t.Errorf("Unexpected subresource updates occurred %#v", unexpected)
+	}
+
+	for i, want := range r.WantDeletes {
+		if i >= len(actions.Deletes) {
+			t.Errorf("Missing delete: %#v", want)
+			continue
+		}
+		got := actions.Deletes[i]
+		if got.GetName() != want.GetName() {
+			t.Errorf("Unexpected delete[%d]: %#v", i, got)
+		}
+		if !r.SkipNamespaceValidation && got.GetNamespace() != expectedNamespace {
+			t.Errorf("Unexpected delete[%d]: %#v", i, got)
+		}
+	}
+	if got, want := len(actions.Deletes), len(r.WantDeletes); got > want {
+		for _, extra := range actions.Deletes[want:] {
+			t.Errorf("Extra delete: %s/%s", extra.GetNamespace(), extra.GetName())
+		}
+	}
+
+	for i, want := range r.WantDeleteCollections {
+		if i >= len(actions.DeleteCollections) {
+			t.Errorf("Missing delete-collection: %#v", want)
+			continue
+		}
+		got := actions.DeleteCollections[i]
+		if got, want := got.GetListRestrictions().Labels, want.GetListRestrictions().Labels; (got != nil) != (want != nil) || got.String() != want.String() {
+			t.Errorf("Unexpected delete-collection[%d].Labels = %v, wanted %v", i, got, want)
+		}
+		if got, want := got.GetListRestrictions().Fields, want.GetListRestrictions().Fields; (got != nil) != (want != nil) || got.String() != want.String() {
+			t.Errorf("Unexpected delete-collection[%d].Fields = %v, wanted %v", i, got, want)
+		}
+		if !r.SkipNamespaceValidation && got.GetNamespace() != expectedNamespace {
+			t.Errorf("Unexpected delete-collection[%d]: %#v, wanted %s", i, got, expectedNamespace)
+		}
+	}
+	if got, want := len(actions.DeleteCollections), len(r.WantDeleteCollections); got > want {
+		for _, extra := range actions.DeleteCollections[want:] {
+			t.Errorf("Extra delete-collection: %#v", extra)
+		}
+	}
+
+	for i, want := range r.WantPatches {
+		if i >= len(actions.Patches) {
+			t.Errorf("Missing patch: %#v; raw: %s", want, string(want.GetPatch()))
+			continue
+		}
+
+		got := actions.Patches[i]
+		if got.GetName() != want.GetName() {
+			t.Errorf("Unexpected patch[%d]: %#v", i, got)
+		}
+		if !r.SkipNamespaceValidation && got.GetNamespace() != expectedNamespace {
+			t.Errorf("Unexpected patch[%d]: %#v", i, got)
+		}
+		if diff := cmp.Diff(string(want.GetPatch()), string(got.GetPatch())); diff != "" {
+			t.Errorf("Unexpected patch(-want, +got): %s", diff)
+		}
+	}
+	if got, want := len(actions.Patches), len(r.WantPatches); got > want {
+		for _, extra := range actions.Patches[want:] {
+			t.Errorf("Extra patch: %#v; raw: %s", extra, string(extra.GetPatch()))
+		}
+	}
+
+	gotEvents := eventList.Events()
+	for i, want := range r.WantEvents {
+		if i >= len(gotEvents) {
+			t.Errorf("Missing event: %s", want)
+			continue
+		}
+
+		if diff := cmp.Diff(want, gotEvents[i]); diff != "" {
+			t.Errorf("unexpected event(-want, +got): %s", diff)
+		}
+	}
+	if got, want := len(gotEvents), len(r.WantEvents); got > want {
+		for _, extra := range gotEvents[want:] {
+			t.Errorf("Extra event: %s", extra)
+		}
+	}
+
+	gotStats := statsReporter.GetServiceReadyStats()
+	if diff := cmp.Diff(r.WantServiceReadyStats, gotStats); diff != "" {
+		t.Errorf("Unexpected service ready stats (-want, +got): %s", diff)
+	}
+
+	for _, verify := range r.PostConditions {
+		verify(t, r)
+	}
+}
+
+func filterUpdatesWithSubresource(
+	subresource string,
+	actions []clientgotesting.UpdateAction) (result []clientgotesting.UpdateAction) {
+	for _, action := range actions {
+		if action.GetSubresource() == subresource {
+			result = append(result, action)
+		}
+	}
+	return
+}
+
+// TableTest represents a list of TableRow tests instances.
+type TableTest []TableRow
+
+// Test executes the whole suite of the table tests.
+func (tt TableTest) Test(t *testing.T, factory Factory) {
+	t.Helper()
+	for _, test := range tt {
+		// Record the original objects in table.
+		originObjects := make([]runtime.Object, 0, len(test.Objects))
+		for _, obj := range test.Objects {
+			originObjects = append(originObjects, obj.DeepCopyObject())
+		}
+		t.Run(test.Name, func(t *testing.T) {
+			t.Helper()
+			test.Test(t, factory)
+		})
+		// Validate cached objects do not get soiled after controller loops
+		if diff := cmp.Diff(originObjects, test.Objects, safeDeployDiff, cmpopts.EquateEmpty()); diff != "" {
+			t.Errorf("Unexpected objects in test %s (-want, +got): %v", test.Name, diff)
+		}
+	}
+}
+
+var (
+	ignoreLastTransitionTime = cmp.FilterPath(func(p cmp.Path) bool {
+		return strings.HasSuffix(p.String(), "LastTransitionTime.Inner.Time")
+	}, cmp.Ignore())
+
+	safeDeployDiff = cmpopts.IgnoreUnexported(resource.Quantity{})
+)

--- a/vendor/knative.dev/pkg/reconciler/testing/tracker.go
+++ b/vendor/knative.dev/pkg/reconciler/testing/tracker.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/tracker"
+)
+
+// NullTracker implements Tracker
+//
+// Alias is preserved for backwards compatibility
+type NullTracker = FakeTracker
+
+// FakeTracker implements Tracker.
+type FakeTracker struct {
+	sync.Mutex
+	references []tracker.Reference
+}
+
+var _ tracker.Interface = (*FakeTracker)(nil)
+
+// OnChanged implements OnChanged.
+func (*FakeTracker) OnChanged(interface{}) {}
+
+// Track implements tracker.Interface.
+func (n *FakeTracker) Track(ref corev1.ObjectReference, obj interface{}) error {
+	return n.TrackReference(tracker.Reference{
+		APIVersion: ref.APIVersion,
+		Kind:       ref.Kind,
+		Namespace:  ref.Namespace,
+		Name:       ref.Name,
+	}, obj)
+}
+
+// TrackReference implements tracker.Interface.
+func (n *FakeTracker) TrackReference(ref tracker.Reference, obj interface{}) error {
+	n.Lock()
+	defer n.Unlock()
+
+	n.references = append(n.references, ref)
+	return nil
+}
+
+// References returns the list of objects being tracked
+func (n *FakeTracker) References() []tracker.Reference {
+	n.Lock()
+	defer n.Unlock()
+
+	return append(n.references[:0:0], n.references...)
+}

--- a/vendor/knative.dev/pkg/reconciler/testing/util.go
+++ b/vendor/knative.dev/pkg/reconciler/testing/util.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package testing includes utilities for testing controllers.
+package testing
+
+import (
+	"regexp"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+// KeyOrDie returns the string key of the Kubernetes object or panics if a key
+// cannot be generated.
+func KeyOrDie(obj interface{}) string {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		panic(err)
+	}
+	return key
+}
+
+// ExpectNormalEventDelivery returns a hook function that can be passed to a
+// Hooks.OnCreate() call to verify that an event of type Normal was created
+// matching the given regular expression. For this expectation to be effective
+// the test must also call Hooks.WaitForHooks().
+func ExpectNormalEventDelivery(t *testing.T, messageRegexp string) CreateHookFunc {
+	t.Helper()
+	wantRegexp, err := regexp.Compile(messageRegexp)
+	if err != nil {
+		t.Fatalf("Invalid regular expression: %v", err)
+	}
+	return func(obj runtime.Object) HookResult {
+		t.Helper()
+		event := obj.(*corev1.Event)
+		if !wantRegexp.MatchString(event.Message) {
+			return HookIncomplete
+		}
+		t.Logf("Got an event message matching %q: %q", wantRegexp, event.Message)
+		if got, want := event.Type, corev1.EventTypeNormal; got != want {
+			t.Errorf("unexpected event Type: %q expected: %q", got, want)
+		}
+		return HookComplete
+	}
+}
+
+// ExpectWarningEventDelivery returns a hook function that can be passed to a
+// Hooks.OnCreate() call to verify that an event of type Warning was created
+// matching the given regular expression. For this expectation to be effective
+// the test must also call Hooks.WaitForHooks().
+func ExpectWarningEventDelivery(t *testing.T, messageRegexp string) CreateHookFunc {
+	t.Helper()
+	wantRegexp, err := regexp.Compile(messageRegexp)
+	if err != nil {
+		t.Fatalf("Invalid regular expression: %v", err)
+	}
+	return func(obj runtime.Object) HookResult {
+		t.Helper()
+		event := obj.(*corev1.Event)
+		if !wantRegexp.MatchString(event.Message) {
+			return HookIncomplete
+		}
+		t.Logf("Got an event message matching %q: %q", wantRegexp, event.Message)
+		if got, want := event.Type, corev1.EventTypeWarning; got != want {
+			t.Errorf("unexpected event Type: %q expected: %q", got, want)
+		}
+		return HookComplete
+	}
+}

--- a/vendor/knative.dev/pkg/system/testing/names.go
+++ b/vendor/knative.dev/pkg/system/testing/names.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"os"
+
+	"knative.dev/pkg/system"
+)
+
+func init() {
+	os.Setenv(system.NamespaceEnvKey, "knative-testing")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -105,6 +105,7 @@ github.com/golang/protobuf/ptypes/timestamp
 github.com/golang/protobuf/ptypes/wrappers
 # github.com/google/go-cmp v0.3.1
 github.com/google/go-cmp/cmp
+github.com/google/go-cmp/cmp/cmpopts
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
@@ -713,8 +714,10 @@ knative.dev/pkg/network
 knative.dev/pkg/network/prober
 knative.dev/pkg/profiling
 knative.dev/pkg/ptr
+knative.dev/pkg/reconciler/testing
 knative.dev/pkg/signals
 knative.dev/pkg/system
+knative.dev/pkg/system/testing
 knative.dev/pkg/test
 knative.dev/pkg/test/ingress
 knative.dev/pkg/test/logging


### PR DESCRIPTION
There are a ton of "ingress with no routes" errors that fix themselves because the trackers actually pick up endpoints being added/changed eventually and thus we start creating the respective routes.

On the other hand, we should fail reconcilation immediately if the tracker can't track properly or if we can't fetch resources for reasons different than "not found".