### PR TITLE
Initialize cluster and HTTP filter when instantiating the external authz

### DIFF
--- a/pkg/envoy/http_connection_manager.go
+++ b/pkg/envoy/http_connection_manager.go
@@ -17,8 +17,6 @@
 package envoy
 
 import (
-	"kourier/pkg/config"
-
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	route "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
@@ -37,10 +35,8 @@ func NewHTTPConnectionManager(virtualHosts []*route.VirtualHost) httpconnectionm
 	// Get the extAuthzConf from envs vars.
 	extAuthzConf := GetExternalAuthzConfig()
 
-	// If ExtAuthz is enabled, generate the extauthz filter
 	if extAuthzConf.Enabled {
-		extAuthzFilter := extAuthzConf.GetExternalAuthZFilter(config.ExternalAuthzCluster)
-		filters = append(filters, &extAuthzFilter)
+		filters = append(filters, extAuthzConf.HTTPFilter)
 	}
 
 	// Append the Router filter at the end.

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -208,7 +208,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 func addExtAuthz(caches *generator.Caches) envoy.ExternalAuthzConfig {
 	extAuthZConfig := envoy.GetExternalAuthzConfig()
 	if extAuthZConfig.Enabled {
-		cluster := extAuthZConfig.GetExtAuthzCluster()
+		cluster := extAuthZConfig.Cluster
 		// This is a special case, as this cluster is not related to an ingress,
 		// The Ingress Name and Ingress Namespace are not really used.
 		caches.AddClusterForIngress(cluster, "__extAuthZCluster", "_internal")


### PR DESCRIPTION
Not too important from a performance view probably, but this signals that those 2 fields can be initialized when the ext authz is nstantiated rather than calculated every time.